### PR TITLE
修复 Issue #14：部分旧版主题 CSS 样式无法正确应用

### DIFF
--- a/backend/internal/engine/asset_manager.go
+++ b/backend/internal/engine/asset_manager.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -14,7 +13,76 @@ import (
 	"github.com/dop251/goja"
 	"github.com/tdewolff/minify/v2"
 	"github.com/tdewolff/minify/v2/css"
+	"github.com/typomedia/lessgo/less"
 )
+
+type lessFileReader struct {
+	baseDir string
+}
+
+func (r *lessFileReader) ReadFile(path string) ([]byte, error) {
+	if filepath.IsAbs(path) {
+		return os.ReadFile(path)
+	}
+	return os.ReadFile(filepath.Join(r.baseDir, path))
+}
+
+func inlineLess(content string, baseDir string, visited map[string]bool) (string, error) {
+	importRe := regexp.MustCompile(`@import\s+["']([^"']+)["'];?`)
+
+	var result bytes.Buffer
+	lastEnd := 0
+
+	matches := importRe.FindAllStringSubmatchIndex(content, -1)
+
+	for _, match := range matches {
+		result.WriteString(content[lastEnd:match[0]])
+
+		importPath := content[match[2]:match[3]]
+
+		if strings.HasPrefix(importPath, "http://") ||
+			strings.HasPrefix(importPath, "https://") ||
+			strings.HasPrefix(importPath, "//") ||
+			strings.HasPrefix(importPath, "~") {
+			result.WriteString(content[match[0]:match[1]])
+			lastEnd = match[1]
+			continue
+		}
+
+		if !strings.HasSuffix(importPath, ".less") {
+			importPath = importPath + ".less"
+		}
+
+		fullPath := importPath
+		if !filepath.IsAbs(importPath) {
+			fullPath = filepath.Join(baseDir, importPath)
+		}
+
+		absPath, _ := filepath.Abs(fullPath)
+		if visited[absPath] {
+			lastEnd = match[1]
+			continue
+		}
+		visited[absPath] = true
+
+		importedContent, err := os.ReadFile(fullPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read import %s: %w", importPath, err)
+		}
+
+		importedBaseDir := filepath.Dir(fullPath)
+		inlined, err := inlineLess(string(importedContent), importedBaseDir, visited)
+		if err != nil {
+			return "", err
+		}
+
+		result.WriteString(inlined)
+		lastEnd = match[1]
+	}
+
+	result.WriteString(content[lastEnd:])
+	return result.String(), nil
+}
 
 // AssetManager handles theme and site asset operations
 type AssetManager struct {
@@ -48,12 +116,10 @@ func (m *AssetManager) CopyThemeAssets(buildDir, themeName string) error {
 	_ = os.WriteFile(themeCacheFile, []byte(themeName), 0644)
 
 	// 1. 检查并编译 LESS 文件
-	// 1. 检查并编译 LESS 文件
 	lessPath := filepath.Join(assetsPath, DirStyles, FileMainLess)
 	hasLess := false
 	if _, err := os.Stat(lessPath); err == nil {
 		hasLess = true
-		// Use compileLess which has optimization
 		if err := m.compileLess(lessPath, buildDir); err != nil {
 			m.logger.Warn("LESS 编译失败", "error", err)
 		}
@@ -97,16 +163,13 @@ func (m *AssetManager) CopyThemeAssets(buildDir, themeName string) error {
 
 // compileLess 编译 LESS 文件为 CSS
 func (m *AssetManager) compileLess(lessPath, buildDir string) error {
-	// 输出路径
 	cssPath := filepath.Join(buildDir, DirStyles, FileMainCSS)
 
-	// 确保输出目录存在
 	if err := os.MkdirAll(filepath.Dir(cssPath), 0755); err != nil {
 		return fmt.Errorf("创建输出目录失败: %w", err)
 	}
 
 	// Optimization: Check if recompilation is needed
-	// If main.css exists and is newer than both main.less and config.json
 	lessInfo, errLess := os.Stat(lessPath)
 	configInfo, errConf := os.Stat(filepath.Join(m.appDir, "config", "config.json"))
 	if errLess == nil {
@@ -122,15 +185,36 @@ func (m *AssetManager) compileLess(lessPath, buildDir string) error {
 		}
 	}
 
-	// 调用 lessc 命令编译
-	cmd := exec.Command("lessc", lessPath, cssPath)
-	output, err := cmd.CombinedOutput()
+	// 读取 LESS 文件内容
+	lessContent, err := os.ReadFile(lessPath)
 	if err != nil {
-		return fmt.Errorf("lessc 编译失败: %w\n输出: %s", err, string(output))
+		return fmt.Errorf("读取 LESS 文件失败: %w", err)
+	}
+
+	// 内联所有 @import 语句
+	stylesDir := filepath.Dir(lessPath)
+	visited := make(map[string]bool)
+	absPath, _ := filepath.Abs(lessPath)
+	visited[absPath] = true
+
+	inlinedContent, err := inlineLess(string(lessContent), stylesDir, visited)
+	if err != nil {
+		return fmt.Errorf("LESS import 内联失败: %w", err)
+	}
+
+	// 使用 lessgo 编译
+	m.logger.Info("正在编译 LESS 文件", "less", lessPath, "css", cssPath)
+	cssContent, err := less.Render(inlinedContent, map[string]interface{}{"compress": false})
+	if err != nil {
+		return fmt.Errorf("LESS 编译失败: %w", err)
+	}
+
+	// 写入 CSS 文件
+	if err := os.WriteFile(cssPath, []byte(cssContent), 0644); err != nil {
+		return fmt.Errorf("写入 CSS 文件失败: %w", err)
 	}
 
 	// 检查并应用 style-override.js
-	// 从 lessPath 推导主题路径 (lessPath 位于 themeDir/assets/styles/main.less)
 	themePath := filepath.Dir(filepath.Dir(filepath.Dir(lessPath)))
 	overridePath := filepath.Join(themePath, FileStyleOverride)
 	if _, err := os.Stat(overridePath); err == nil {
@@ -138,16 +222,9 @@ func (m *AssetManager) compileLess(lessPath, buildDir string) error {
 		customCSS, err := m.applyStyleOverride(overridePath)
 		if err != nil {
 			m.logger.Warn("应用 style-override.js 失败", "error", err)
-		} else {
-			// 读取编译后的 CSS
-			cssContent, err := os.ReadFile(cssPath)
-			if err != nil {
-				return fmt.Errorf("读取 CSS 文件失败: %w", err)
-			}
-
-			// 追加自定义 CSS
-			cssContent = append(cssContent, []byte("\n"+customCSS)...)
-			if err := os.WriteFile(cssPath, cssContent, 0644); err != nil {
+		} else if customCSS != "" {
+			cssContent = cssContent + "\n/* style-override */\n" + customCSS
+			if err := os.WriteFile(cssPath, []byte(cssContent), 0644); err != nil {
 				return fmt.Errorf("写入 CSS 文件失败: %w", err)
 			}
 			m.logger.Info("自定义样式应用成功")
@@ -324,12 +401,31 @@ func copyDir(src, dst string) error {
 
 // BundleCSS 合并压缩主题 CSS 文件，减少 HTTP 请求
 func (m *AssetManager) BundleCSS(buildDir, themePath string) error {
-	// 1. 读取 head.html 模板，提取 CSS 文件列表和顺序
-	headPath := filepath.Join(themePath, DirTemplates, "partials", "head.html")
-	headContent, err := os.ReadFile(headPath)
-	if err != nil {
-		return fmt.Errorf("读取 head.html 失败: %w", err)
+	// 支持多种模板引擎的 head 文件位置
+	headPaths := []string{
+		filepath.Join(themePath, DirTemplates, "partials", "head.html"),
+		filepath.Join(themePath, DirTemplates, "partials", "head.ejs"),
+		filepath.Join(themePath, DirTemplates, "includes", "head.html"),
+		filepath.Join(themePath, DirTemplates, "includes", "head.ejs"),
+		filepath.Join(themePath, DirTemplates, "_blocks", "head.html"),
+		filepath.Join(themePath, DirTemplates, "_blocks", "head.ejs"),
 	}
+
+	var headContent []byte
+	var headPath string
+	var err error
+	for _, p := range headPaths {
+		headContent, err = os.ReadFile(p)
+		if err == nil {
+			headPath = p
+			break
+		}
+	}
+	if headContent == nil {
+		m.logger.Info("未找到 head 模板文件，跳过 CSS 合并")
+		return nil
+	}
+	m.logger.Info("使用 head 模板", "path", headPath)
 
 	// 提取 /styles/xxx.css 引用
 	cssRefRe := regexp.MustCompile(`href="/styles/([\w.\-]+\.css)"`)

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/mozillazg/go-pinyin v0.21.0
 	github.com/pkg/sftp v1.13.10
 	github.com/tdewolff/minify/v2 v2.24.10
+	github.com/typomedia/lessgo v0.1.1
 	github.com/wailsapp/wails/v2 v2.11.0
 	github.com/yuin/goldmark v1.7.16
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.48.0
 	golang.org/x/image v0.38.0
 	golang.org/x/net v0.50.0
@@ -34,6 +36,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
@@ -78,7 +81,6 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/zalando/go-keyring v0.2.8 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20260106131823-651366fbe6e3 h1:bVp3yUzvSAJzu9GqID+Z96P+eu5TKnIMJSV4QaZMauM=
 github.com/dop251/goja v0.0.0-20260106131823-651366fbe6e3/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
+github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc h1:MKYt39yZJi0Z9xEeRmDX2L4ocE0ETKcHKw6MVL3R+co=
+github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc/go.mod h1:VULptt4Q/fNzQUJlqY/GP3qHyU7ZH46mFkBZe0ZTokU=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -151,6 +153,8 @@ github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQ
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -163,6 +167,8 @@ github.com/tdewolff/test v1.0.11 h1:FdLbwQVHxqG16SlkGveC0JVyrJN62COWTRyUFzfbtBE=
 github.com/tdewolff/test v1.0.11/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
+github.com/typomedia/lessgo v0.1.1 h1:Wv3lzQhXutQ/vVFkq7RSAbvdIipsXT5eL7Pdtp6KWj0=
+github.com/typomedia/lessgo v0.1.1/go.mod h1:2LDfDuOLI5b17e3vjtA1h6lQgBqQDRk/P5fn3V+lZNU=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=


### PR DESCRIPTION
### 问题描述

旧版 Gridea 的主题使用 `.less` 文件编写样式，但 Gridea Pro 之前依赖外部的 `lessc` 命令（需手动安装 Node.js 和 lessc）。如果用户未安装 lessc，LESS 编译会静默失败，导致浏览器访问时 CSS 返回 404。

### 解决方案

1. **移除外部依赖** - 改用纯 Go 实现的 [lessgo](https://github.com/typomedia/lessgo) 库（基于 goja 运行 JavaScript 版本的 Less.js），无需用户安装任何外部工具
2. **修复 Import 路径解析** - lessgo 库本身存在 `@import` 语句的路径解析 bug（Less.js 在 goja 运行时无法自动添加 `.less` 扩展名），通过添加 `inlineLess` 函数在编译前将所有 `@import` 语句展开为内联内容解决
3. **兼容多种主题结构** - `BundleCSS` 现在支持多种模板引擎的 head 文件位置（`partials`、`includes`、`_blocks` 下的 `head.html` 或 `head.ejs`）

### 改动范围

- `backend/internal/engine/asset_manager.go` - 核心修复
- `go.mod` / `go.sum` - 新增 lessgo 依赖

### 测试

已在本地使用旧版 Gridea 主题（simple）验证 LESS 编译功能正常工作。
关联 Issue: #14
分支已推送至 origin/fix/issue-14。