### PR TITLE
修复 Issue #13: Monaco 编辑器命令面板错位问题

### DIFF
--- a/frontend/src/components/MonacoMarkdownEditor/index.vue
+++ b/frontend/src/components/MonacoMarkdownEditor/index.vue
@@ -4,7 +4,7 @@
     margin: '0 auto',
     width: props.isPostPage ? '728px' : '100%',
     position: 'relative',
-    overflow: 'hidden'
+    overflow: 'visible'
   }">
     <div ref="elRef" class="monaco-editor-container w-full h-full" style="flex: 1;" />
     <!-- 模板级占位符，比 CSS 方案更可靠 -->
@@ -369,5 +369,23 @@ defineExpose({
   .selected-text {
     background-color: #FFEBB7 !important;
   }
+}
+</style>
+
+<style>
+/* 全局强制修复 Monaco Command Palette (F1) 的居中和被裁切问题 */
+.quick-input-widget {
+  position: fixed !important;
+  top: 15vh !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+  margin-left: 0 !important;
+  width: 600px !important;
+  max-width: 90vw !important;
+}
+
+/* 防止可能的列表动画冲突导致错位 */
+.quick-input-widget .monaco-list-row {
+  transform: none !important;
 }
 </style>

--- a/frontend/src/views/articles/editor/index.vue
+++ b/frontend/src/views/articles/editor/index.vue
@@ -282,8 +282,6 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     flex: 1;
-    overflow-y: hidden;
-    overflow-x: hidden;
 
     .post-title {
         width: 728px;


### PR DESCRIPTION
### 问题描述

在编辑器中右键或按 F1 唤出命令面板（Command Palette）时，面板严重向右偏移——始终以编辑器内容区左边缘为中点，而非屏幕水平居中。

### 根因分析

两处 CSS 问题叠加导致：

1. `.editor-wrapper` 和 `.monaco-editor-wrapper` 设置了 `overflow: hidden`，当 Monaco 的浮动组件（如命令面板）渲染在容器边界外时，被裁切掉了。
2. Monaco 内部组件使用 `position: fixed` 渲染到 `body`，但 `overflow: hidden` + `margin: 0 auto` 的居中布局干扰了坐标系计算，导致 x 坐标以居中容器为参考而非视口。

### 解决方案
1. 移除 `frontend/src/views/articles/editor/index.vue` 中 `.editor-wrapper` 的 `overflow-y/x: hidden`
2. 将 `frontend/src/components/MonacoMarkdownEditor/index.vue` 中 `.monaco-editor-wrapper` 的 `overflow: hidden` 改为 `overflow: visible`
3. 通过全局 CSS 强制 `.quick-input-widget` 水平居中于屏幕（`left: 50%` + `transform: translateX(-50%)`），不受任何父级布局影响

### 涉及文件
- `frontend/src/views/articles/editor/index.vue`
- `frontend/src/components/MonacoMarkdownEditor/index.vue`

关联 Issue: #13
分支已推送至 `origin/fix/issue-13`