### PR TITLE
修复 Issue #10: 窗口位置在打开设置时被重置

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -425,7 +425,6 @@ func (a *App) ShowPreferences() {
 	if a.ctx == nil {
 		return
 	}
-	runtime.WindowCenter(a.ctx)
 	runtime.EventsEmit(a.ctx, EventShowPreferencesDialog)
 }
 


### PR DESCRIPTION
### 问题描述

点击「设置」后，窗口会自动跳回屏幕中央，而非保持在之前的位置。用户手动调整窗口位置后，每次打开设置都会被覆盖，体验不佳。

### 根因分析

在 `backend/internal/app/app.go` 的 `ShowPreferences()` 函数中，每次调用都会执行 `runtime.WindowCenter(a.ctx)`，强制将窗口居中。这个行为是不必要的——窗口位置应该由用户自己控制。

### 解决方案

移除 `ShowPreferences()` 中多余的 `runtime.WindowCenter(a.ctx)` 调用，窗口位置即可得到保留。

### 改动范围

- `backend/internal/app/app.go` - 删除 1 行

### 复现步骤

1. 将 Gridea Pro 窗口拖动到屏幕任意位置（不在中心）
2. 点击「设置」
3. 窗口自动跳回屏幕中央 ← 这是 Bug
4. 修复后，窗口位置会保持不变

关联 Issue: #10  
分支已推送至 `origin/fix/issue-10`。