### PR TITLE
实现 Issue #11: 编辑器字体切换

### DIFF
--- a/frontend/src/components/MonacoMarkdownEditor/index.vue
+++ b/frontend/src/components/MonacoMarkdownEditor/index.vue
@@ -170,8 +170,7 @@ const initEditor = () => {
     links: false,
     automaticLayout: true,
     padding: { top: 24, bottom: 64 },
-    fontFamily:
-      'ui-monospace, Menlo, Monaco, "Cascadia Code", "Segoe UI Mono", Consolas, "Courier New", monospace',
+    fontFamily: themeStore.editorFontFamily,
     unicodeHighlight: {
       ambiguousCharacters: false,
       invisibleCharacters: false,
@@ -277,6 +276,15 @@ watch(isEmpty, (val) => {
     editorRef.value.updateOptions({ scrollBeyondLastLine: !val })
   }
 })
+
+watch(
+  () => themeStore.editorFontFamily,
+  (fontFamily) => {
+    if (editorRef.value) {
+      editorRef.value.updateOptions({ fontFamily })
+    }
+  },
+)
 
 // ─── 暴露给父组件 ─────────────────────────────────────────────────────────────
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -440,7 +440,10 @@
         "colorWarm": "Sonnenuntergang",
         "colorSakura": "Sakura-Rosa",
         "colorTwilight": "Dämmerungslila",
-        "colorGlass": "Milchglas"
+        "colorGlass": "Milchglas",
+        "editorFontFamily": "Editor-Schriftart",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "Mehrere Schriftarten durch Kommas getrennt; die erste verfügbare Schriftart wird verwendet"
     },
     "shortcutKeys": {
         "editing": "Bearbeitung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -440,7 +440,10 @@
         "colorWarm": "Sunset Warm",
         "colorSakura": "Sakura Pink",
         "colorTwilight": "Twilight Purple",
-        "colorGlass": "Frosted Glass"
+        "colorGlass": "Frosted Glass",
+        "editorFontFamily": "Editor Font Family",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "Multiple fonts separated by commas; the first available font is used"
     },
     "shortcutKeys": {
         "editing": "Editing",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -440,7 +440,10 @@
         "colorWarm": "Cálido atardecer",
         "colorSakura": "Rosa sakura",
         "colorTwilight": "Púrpura crepúsculo",
-        "colorGlass": "Cristal esmerilado"
+        "colorGlass": "Cristal esmerilado",
+        "editorFontFamily": "Fuente del editor",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "Múltiples fuentes separadas por comas; se usa la primera fuente disponible"
     },
     "shortcutKeys": {
         "editing": "Edición",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -440,7 +440,10 @@
         "colorWarm": "Coucher de soleil",
         "colorSakura": "Rose sakura",
         "colorTwilight": "Violet crépuscule",
-        "colorGlass": "Verre dépoli"
+        "colorGlass": "Verre dépoli",
+        "editorFontFamily": "Police de l'éditeur",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "Plusieurs polices séparées par des virgules ; la première police disponible est utilisée"
     },
     "shortcutKeys": {
         "editing": "Édition",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -440,7 +440,10 @@
         "colorWarm": "Tramonto caldo",
         "colorSakura": "Rosa sakura",
         "colorTwilight": "Viola crepuscolo",
-        "colorGlass": "Vetro smerigliato"
+        "colorGlass": "Vetro smerigliato",
+        "editorFontFamily": "Font dell'editor",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "Font multipli separati da virgole; viene utilizzato il primo font disponibile"
     },
     "shortcutKeys": {
         "editing": "Modifica",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -440,7 +440,10 @@
         "colorWarm": "サンセットウォーム",
         "colorSakura": "桜ピンク",
         "colorTwilight": "トワイライトパープル",
-        "colorGlass": "すりガラス"
+        "colorGlass": "すりガラス",
+        "editorFontFamily": "エディターフォント",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "複数のフォントは英字カンマで区切り、率先使用的是前面的字体"
     },
     "shortcutKeys": {
         "editing": "編集",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -440,7 +440,10 @@
         "colorWarm": "선셋 웜",
         "colorSakura": "벚꽃 핑크",
         "colorTwilight": "석양 퍼플",
-        "colorGlass": "프로스트 글래스"
+        "colorGlass": "프로스트 글래스",
+        "editorFontFamily": "편집기 폰트",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "여러 폰트는 영문 쉼표로 구분하며, 먼저 나오는 폰트가 우선 사용됩니다"
     },
     "shortcutKeys": {
         "editing": "편집",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -440,7 +440,10 @@
         "colorWarm": "Pôr do Sol",
         "colorSakura": "Rosa Sakura",
         "colorTwilight": "Roxo Crepúsculo",
-        "colorGlass": "Vidro Fosco"
+        "colorGlass": "Vidro Fosco",
+        "editorFontFamily": "Fonte do editor",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "Múltiplas fontes separadas por vírgulas; a primeira fonte disponível é usada"
     },
     "shortcutKeys": {
         "editing": "Edição",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -440,7 +440,10 @@
         "colorWarm": "Тёплый закат",
         "colorSakura": "Сакура",
         "colorTwilight": "Сумеречный фиолетовый",
-        "colorGlass": "Матовое стекло"
+        "colorGlass": "Матовое стекло",
+        "editorFontFamily": "Шрифт редактора",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "Несколько шрифтов через запятую; используется первый доступный шрифт"
     },
     "shortcutKeys": {
         "editing": "Редактирование",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -470,7 +470,10 @@
     "colorWarm": "日落暖",
     "colorSakura": "樱花粉",
     "colorTwilight": "暮山紫",
-    "colorGlass": "毛玻璃"
+    "colorGlass": "毛玻璃",
+    "editorFontFamily": "编辑器字体",
+    "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+    "editorFontFamilyHint": "多个字体用英文逗号分隔，前面的字体优先使用"
   },
   "shortcutKeys": {
     "editing": "编辑",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -440,7 +440,10 @@
         "colorWarm": "日落暖",
         "colorSakura": "櫻花粉",
         "colorTwilight": "暮山紫",
-        "colorGlass": "毛玻璃"
+        "colorGlass": "毛玻璃",
+        "editorFontFamily": "編輯器字體",
+        "editorFontFamilyPlaceholder": "Menlo, Monaco, Consolas, monospace",
+        "editorFontFamilyHint": "多個字體用英文逗號分隔，前面的字體優先使用"
     },
     "shortcutKeys": {
         "editing": "編輯",

--- a/frontend/src/stores/theme.ts
+++ b/frontend/src/stores/theme.ts
@@ -4,6 +4,9 @@ import { ref, computed } from 'vue'
 export type ThemeMode = 'light' | 'dark' | 'system'
 export type ThemeColor = 'default' | 'blue' | 'warm' | 'sakura' | 'twilight' | 'glass'
 
+export const EDITOR_FONT_FAMILY_DEFAULT =
+  'ui-monospace, Menlo, Monaco, "Cascadia Code", "Segoe UI Mono", Consolas, "Courier New", monospace'
+
 export const useThemeStore = defineStore('theme', () => {
   // State
   const mode = ref<ThemeMode>(
@@ -14,6 +17,9 @@ export const useThemeStore = defineStore('theme', () => {
   )
   const systemIsDark = ref(
     window.matchMedia('(prefers-color-scheme: dark)').matches
+  )
+  const editorFontFamily = ref<string>(
+    localStorage.getItem('app_editor_font_family') || EDITOR_FONT_FAMILY_DEFAULT
   )
 
   // Getters
@@ -65,6 +71,11 @@ export const useThemeStore = defineStore('theme', () => {
     applyTheme()
   }
 
+  function setEditorFontFamily(value: string) {
+    editorFontFamily.value = value
+    localStorage.setItem('app_editor_font_family', value)
+  }
+
   function initTheme() {
     applyTheme()
     // Listen for system changes
@@ -84,12 +95,14 @@ export const useThemeStore = defineStore('theme', () => {
     mode,
     theme,
     systemIsDark,
+    editorFontFamily,
     // Getters
     isDark,
     antDesignTheme,
     // Actions
     setMode,
     setTheme,
+    setEditorFontFamily,
     applyTheme,
     initTheme
   }

--- a/frontend/src/views/preferences/components/AppSetting.vue
+++ b/frontend/src/views/preferences/components/AppSetting.vue
@@ -45,6 +45,16 @@
         </div>
       </div>
     </div>
+
+    <div>
+      <div class="text-sm font-medium text-[var(--text-secondary)] mb-4">{{ t('preferences.editorFontFamily') }}</div>
+      <Input
+        v-model="editorFontFamily"
+        :placeholder="t('preferences.editorFontFamilyPlaceholder')"
+        class="max-w-md font-mono text-sm"
+      />
+      <div class="text-xs text-[var(--text-secondary)] mt-2">{{ t('preferences.editorFontFamilyHint') }}</div>
+    </div>
   </div>
 </template>
 
@@ -53,6 +63,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useThemeStore, ThemeMode, ThemeColor } from '@/stores/theme'
 import { SunIcon, MoonIcon, ComputerDesktopIcon, CheckIcon } from '@heroicons/vue/24/outline'
+import { Input } from '@/components/ui/input'
 
 const { t } = useI18n()
 const themeStore = useThemeStore()
@@ -65,6 +76,11 @@ const mode = computed({
 const theme = computed({
   get: () => themeStore.theme,
   set: (val) => themeStore.setTheme(val)
+})
+
+const editorFontFamily = computed({
+  get: () => themeStore.editorFontFamily,
+  set: (val) => themeStore.setEditorFontFamily(val),
 })
 
 const modeOptions = computed(() => [


### PR DESCRIPTION
### 问题描述

Issue #11 中提到，Markdown 编辑器默认使用系统字体，部分用户（如 Windows 11 中文用户）看到的是宋体等不适合编写代码的字体。希望能在设置中自定义编辑器字体。

### 解决方案

在 设置 → 外观 中新增"编辑器字体"输入框，用户填写字体名称（支持多字体英文逗号分隔），顺序即优先级。修改即时生效，无需重启应用。

### 改动范围

- `frontend/src/stores/theme.ts`：新增 `editorFontFamily` 状态和 `setEditorFontFamily` action，持久化至 localStorage
- `frontend/src/components/MonacoMarkdownEditor/index.vue`：接入 `themeStore.editorFontFamily`，新增 watch 实时响应字体变更
- `frontend/src/views/preferences/components/AppSetting.vue`：Appearance 设置页新增字体输入框（font-mono 风格）
- `frontend/src/locales/*.json`：11 种语言新增 `editorFontFamily`、`editorFontFamilyPlaceholder`、`editorFontFamilyHint` 三个 i18n key

### 测试

已在本地验证：输入自定义字体名称（如 "Noto Serif SC", "Sarasa Gothic SC"）后，编辑器字体即时切换。
关联 Issue: #11 