### PR TITLE
feat(ui): 禁用非输入区域的文字选中功能

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -219,10 +219,14 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-/* 恢复输入框的系统原生选中文本机制（解决 Wails WKWebView 下无法 Cmd+V 粘贴的问题） */
+/* 恢复输入框和编辑器的系统原生选中文本机制 */
 input,
 textarea,
-[contenteditable="true"] {
+[contenteditable="true"],
+.monaco-editor,
+.monaco-editor *,
+.monaco-editor-wrapper,
+.monaco-editor-container {
   -webkit-user-select: auto !important;
   user-select: auto !important;
 }

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -106,7 +106,7 @@ fill-rule="evenodd" clip-rule="evenodd"
     </aside>
 
     <!-- Main Content -->
-    <main class="flex-1 flex flex-col min-h-0 overflow-hidden bg-background">
+    <main class="flex-1 flex flex-col min-h-0 overflow-hidden bg-background select-none">
       <div class="flex-1 w-full overflow-y-auto overflow-x-hidden p-0">
         <router-view v-slot="{ Component }">
           <keep-alive exclude="Loading,Theme">


### PR DESCRIPTION
### 问题描述

文章、菜单、分类、标签等列表页面充满可点击的项目（卡片），用户在操作时容易误选中文字，影响用户体验。

### 解决方案

1. **全局禁用选中** - 在 `MainLayout.vue` 的主内容区添加 `select-none` 类，默认禁止所有内容区域的文字选中
2. **白名单机制** - 在 `App.vue` 中通过 CSS 选择器恢复输入框和 Monaco 编辑器的文字选中能力：
   - `input`, `textarea` - 普通输入框
   - `[contenteditable="true"]` - 可编辑元素
   - `.monaco-editor`, `.monaco-editor *`, `.monaco-editor-wrapper`, `.monaco-editor-container` - 代码编辑器

### 改动范围

- `frontend/src/layouts/MainLayout.vue` - 主内容区添加 `select-none`
- `frontend/src/App.vue` - 扩展 CSS 白名单，允许编辑器选中

### 测试

- 文章列表、菜单、标签、分类、链接等页面文字不可选中
- 文章编辑页标题输入框可正常选中
- Monaco 编辑器内容可正常选中

Closes #24