### PR TITLE
fix(preferences): 修复站点列表项溢出对话框问题

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md
+
+本文件用于记录 AI 助手（如 GitHub Copilot、Cursor 等）在项目中需要遵循的约定和示例。
+
+## Commit 信息规范
+
+遵循 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/) 规范：
+
+```
+<类型>(<范围>): <简短描述> (#PR号)
+
+[可选的正文：问题描述、原因分析、解决方案]
+
+Closes #关联Issue号
+```
+
+### 类型
+
+| 类型 | 说明 |
+|------|------|
+| `feat` | 新功能 |
+| `fix` | Bug 修复 |
+| `refactor` | 代码重构（不改变功能） |
+| `docs` | 文档更新 |
+| `style` | 代码格式调整（不影响逻辑） |
+| `perf` | 性能优化 |
+| `test` | 测试相关 |
+| `chore` | 构建、CI、依赖等杂项 |
+
+### 范围
+
+范围用于指定改动的模块或文件，例如：
+- `window` - 窗口相关
+- `editor` - 编辑器相关
+- `theme` - 主题相关
+- `i18n` - 国际化相关
+- `oauth` - OAuth 认证相关
+
+### 示例
+
+```
+fix(window): 移除 ShowPreferences 中多余的 WindowCenter 调用 (#17)
+
+点击设置后窗口会自动回到屏幕中央，而非保持在之前的位置。
+这是因为 ShowPreferences() 每次调用都会执行 runtime.WindowCenter()，
+将窗口强制居中，覆盖了用户手动调整的位置。
+
+移除多余的 WindowCenter 调用即可解决问题。
+
+Closes #10
+```
+
+---
+
+## Pull Request 创建示例
+
+以下是创建 PR 时的描述模板和示例：
+
+**重要：** 在 PR 描述的末尾必须添加 `Closes #XX` 标签，这样当 PR 被合并时，GitHub 会自动关闭关联的 Issue。
+
+### PR 描述模板
+
+```markdown
+### 问题描述
+
+[简要描述问题或需求背景]
+
+### 解决方案
+
+1. **[方案要点一]** - [具体说明]
+2. **[方案要点二]** - [具体说明]
+3. **[方案要点三]** - [具体说明]
+
+### 改动范围
+
+- `path/to/file1.go` - [改动说明]
+- `path/to/file2.ts` - [改动说明]
+
+### 测试
+
+[测试方法和验证结果]
+关联 Issue: #XX
+分支已推送至 origin/fix/issue-XX。
+
+Closes #XX
+```
+
+### PR 描述示例
+
+以下是一个真实的 PR 描述示例：
+
+```markdown
+### 问题描述
+
+旧版 Gridea 的主题使用 `.less` 文件编写样式，但 Gridea Pro 之前依赖外部的 `lessc` 命令（需手动安装 Node.js 和 lessc）。如果用户未安装 lessc，LESS 编译会静默失败，导致浏览器访问时 CSS 返回 404。
+
+### 解决方案
+
+1. **移除外部依赖** - 改用纯 Go 实现的 [lessgo](https://github.com/typomedia/lessgo) 库（基于 goja 运行 JavaScript 版本的 Less.js），无需用户安装任何外部工具
+2. **修复 Import 路径解析** - lessgo 库本身存在 `@import` 语句的路径解析 bug（Less.js 在 goja 运行时无法自动添加 `.less` 扩展名），通过添加 `inlineLess` 函数在编译前将所有 `@import` 语句展开为内联内容解决
+3. **兼容多种主题结构** - `BundleCSS` 现在支持多种模板引擎的 head 文件位置（`partials`、`includes`、`_blocks` 下的 `head.html` 或 `head.ejs`）
+
+### 改动范围
+
+- `backend/internal/engine/asset_manager.go` - 核心修复
+- `go.mod` / `go.sum` - 新增 lessgo 依赖
+
+### 测试
+
+已在本地使用旧版 Gridea 主题（simple）验证 LESS 编译功能正常工作。
+关联 Issue: #14。
+
+Closes #14
+```
+
+---
+
+## Issue 处理流程
+
+处理 Issue 时需遵循以下标准流程：
+
+### 1. 切换到 main 分支
+
+```bash
+git checkout main
+```
+
+### 2. 拉取上游最新代码
+
+```bash
+git pull upstream main
+# 如果没有配置 upstream，先添加：
+git remote add upstream https://github.com/Gridea-Pro/gridea-pro.git
+```
+
+### 3. 从 main 分支创建新分支
+
+**重要：必须从 main 分支创建新分支**
+
+```bash
+git checkout -b <类型>/<issue号或描述>
+```
+
+分支命名规范（参考 CONTRIBUTING.md）：
+
+| 前缀 | 用途 | 示例 |
+|------|------|------|
+| `feat/` | 新功能 | `feat/dark-mode` |
+| `fix/` | Bug 修复 | `fix/issue-24` |
+| `docs/` | 文档 | `docs/api-reference` |
+| `refactor/` | 代码重构 | `refactor/renderer` |
+| `chore/` | 工具、CI、依赖 | `chore/update-deps` |
+
+### 4. 处理 Issue
+
+1. 阅读并理解 Issue 描述
+2. 探索相关代码
+3. 实现修复或功能
+4. 运行 lint 和 format 确保代码规范
+5. 提交代码（遵循 Commit 信息规范）
+6. 推送分支并创建 PR
+
+---
+
+## 其他约定
+
+（待补充）

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -146,11 +146,11 @@ href="#" class="text-primary hover:underline"
     </Dialog>
 
     <Dialog v-model:open="systemModalVisible">
-      <DialogContent class="max-w-[800px]">
+      <DialogContent class="max-w-[800px] overflow-hidden">
         <DialogHeader>
           <DialogTitle>{{ t('settings.basic.title') }}</DialogTitle>
         </DialogHeader>
-        <div class="h-[600px]">
+        <div class="h-[600px] overflow-hidden">
           <app-system />
         </div>
       </DialogContent>

--- a/frontend/src/views/preferences/index.vue
+++ b/frontend/src/views/preferences/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex h-full min-h-[400px] bg-background rounded-xl overflow-hidden text-foreground">
+  <div class="flex h-full min-h-[400px] w-full max-w-full bg-background rounded-xl overflow-hidden text-foreground">
     <!-- 左侧导航 -->
     <div class="w-[200px] bg-secondary/20 py-4 px-2 border-r border-border">
       <div class="flex flex-col gap-1">
@@ -14,7 +14,7 @@ v-for="item in navItems" :key="item.key"
     </div>
 
     <!-- 右侧内容 -->
-    <div class="flex-1 p-8 overflow-y-auto">
+    <div class="flex-1 min-w-0 max-w-full p-8 overflow-y-auto overflow-x-hidden">
       <!-- 外观设置 -->
       <div v-if="activeTab === 'appearance'" class="animate-fade-in">
         <h2 class="text-xl font-semibold mb-6 text-foreground">{{ t('settings.theme.appearance') }}</h2>
@@ -44,8 +44,8 @@ v-for="item in navItems" :key="item.key"
       </div>
 
       <!-- 站点管理 -->
-      <div v-if="activeTab === 'sites'" class="animate-fade-in">
-        <div class="flex justify-between items-center mb-6">
+      <div v-if="activeTab === 'sites'" class="animate-fade-in flex flex-col min-w-0">
+        <div class="flex justify-between items-center mb-6 flex-shrink-0">
           <h2 class="text-xl font-semibold text-foreground">{{ t('settings.sites.title') }}</h2>
           <Button variant="outline" size="sm" class="h-8 px-3 text-xs rounded-full" @click="handleAddSite">
             <PlusIcon class="size-4 mr-1" />
@@ -53,42 +53,44 @@ v-for="item in navItems" :key="item.key"
           </Button>
         </div>
 
-        <draggable v-model="sites" handle=".handle" item-key="path" @change="handleSiteSort">
+        <draggable v-model="sites" handle=".handle" item-key="path" class="w-full min-w-0 flex-1 overflow-y-auto overflow-x-hidden" @change="handleSiteSort">
           <template #item="{ element: site }">
             <div
-              class="group flex items-center gap-3 px-4 py-3 mb-2 rounded-lg border transition-all duration-200"
+              class="group flex w-full min-w-0 max-w-full items-center gap-3 px-4 py-3 mb-2 rounded-lg border transition-all duration-200 overflow-hidden"
               :class="site.active
                 ? 'bg-primary/5 border-primary/30'
                 : 'bg-card/50 border-border/50 hover:bg-primary/2 hover:border-primary/20'">
               <!-- 拖拽手柄 -->
-              <div class="handle cursor-move text-muted-foreground/40 hover:text-muted-foreground">
+              <div class="handle flex-shrink-0 cursor-move text-muted-foreground/40 hover:text-muted-foreground">
                 <Bars3Icon class="size-3.5" />
               </div>
 
               <!-- 站点信息 -->
-              <div class="flex-1 min-w-0">
-                <div class="text-sm font-medium text-foreground truncate">{{ site.name }}</div>
-                <div class="text-xs text-muted-foreground/60 truncate mt-0.5">{{ site.path }}</div>
+              <div class="flex-1 min-w-0 overflow-hidden">
+                <div class="text-sm font-medium text-foreground truncate block w-full">{{ site.name }}</div>
+                <div class="text-xs text-muted-foreground/60 truncate mt-0.5 block w-full">{{ site.path }}</div>
               </div>
 
               <!-- 编辑按钮 -->
               <button
-                class="text-muted-foreground/30 hover:text-foreground transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
+                class="flex-shrink-0 text-muted-foreground/30 hover:text-foreground transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
                 @click="handleEditSite(site)">
                 <PencilIcon class="size-3.5" />
               </button>
 
               <!-- 删除按钮 -->
               <button
-                class="text-muted-foreground/30 hover:text-destructive transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
+                class="flex-shrink-0 text-muted-foreground/30 hover:text-destructive transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
                 @click="handleDeleteSite(site)">
                 <TrashIcon class="size-3.5" />
               </button>
 
               <!-- Switch 开关 -->
-              <Switch
-                :checked="site.active" size="sm"
-                @update:checked="(v: boolean) => handleSwitchSite(site, v)" />
+              <div class="flex-shrink-0">
+                <Switch
+                  :checked="site.active" size="sm"
+                  @update:checked="(v: boolean) => handleSwitchSite(site, v)" />
+              </div>
             </div>
           </template>
         </draggable>


### PR DESCRIPTION
### 问题描述

在"设置 > 站点"页面中，当站点路径过长时，站点列表项会溢出母容器边界，导致UI显示异常。

### 解决方案

1. **添加宽度约束** - 为 preferences 根元素添加 `w-full max-w-full` 类，确保整个组件不会超出容器宽度
2. **防止水平溢出** - 为右侧内容区域添加 `max-w-full overflow-x-hidden` 类，防止水平方向溢出
3. **对话框溢出控制** - 为 MainLayout 中的 DialogContent 和包裹 app-system 的 div 添加 `overflow-hidden` 类
4. **文本截断优化** - 确保站点名称和路径的 `truncate` 类能正常工作，长文本会被正确截断显示

### 改动范围

- `frontend/src/views/preferences/index.vue` - 主要修复文件
- `frontend/src/layouts/MainLayout.vue` - 对话框容器溢出控制

### 测试

已在本地验证站点列表项中的长路径能被正确截断，不会溢出对话框边界。
关联 Issue: #23


Closes #23 