### PR TITLE
feat(editor): 标题下方显示文章日期、分类和标签信息

### DIFF
--- a/frontend/src/views/articles/editor/index.vue
+++ b/frontend/src/views/articles/editor/index.vue
@@ -10,9 +10,27 @@
         <div class="page-content">
             <div class="editor-wrapper">
                 <input ref="titleInputRef" v-model="form.title"
-                    class="post-title py-4 border-none pt-10 pb-10 bg-transparent text-xl focus:outline-none focus:ring-0 text-foreground placeholder:text-muted-foreground/50 font-bold"
+                    class="post-title py-4 border-none pt-10 pb-2 bg-transparent text-xl focus:outline-none focus:ring-0 text-foreground placeholder:text-muted-foreground/50 font-bold"
                     :placeholder="$t('article.title')" @change="handleTitleChange" @focus="handleTitleFocus"
                     @keydown="(e: KeyboardEvent) => handleInputKeydown(e, form.content)" />
+
+                <div class="post-meta">
+                    <span class="meta-item">
+                        <CalendarIcon class="meta-icon" />
+                        {{ form.createdAt.isValid() ? form.createdAt.format('YYYY-MM-DD') : '' }}
+                    </span>
+                    <span v-if="form.category" class="meta-item">
+                        <FolderIcon class="meta-icon" />
+                        {{ form.category }}
+                    </span>
+                    <span v-if="form.tags.length" class="meta-item">
+                        <TagIcon class="meta-icon" />
+                        {{ form.tags.join(', ') }}
+                    </span>
+                    <span class="meta-item meta-status" :class="form.published ? 'text-emerald-500' : 'text-amber-500'">
+                        {{ form.published ? $t('article.published') : $t('article.draft') }}
+                    </span>
+                </div>
 
                 <monaco-markdown-editor ref="monacoMarkdownEditor" v-model:value="form.content" :is-post-page="true"
                     :placeholder="$t('article.editorPlaceholder')"
@@ -57,6 +75,8 @@ import MonacoMarkdownEditor from '@/components/MonacoMarkdownEditor/index.vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@/helpers/toast'
 import { GenerateSlug } from '@/wailsjs/go/facade/AIFacade'
+
+import { CalendarIcon, FolderIcon, TagIcon } from '@heroicons/vue/24/outline'
 
 import EditorHeader from './components/EditorHeader.vue'
 import ArticleSettingsDrawer from './components/ArticleSettingsDrawer.vue'
@@ -287,6 +307,35 @@ onUnmounted(() => {
         width: 728px;
         margin: 0 auto;
         display: block;
+    }
+
+    .post-meta {
+        width: 728px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding-bottom: 16px;
+        font-size: 12px;
+        color: var(--muted-foreground);
+        flex-wrap: wrap;
+
+        .meta-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .meta-icon {
+            width: 14px;
+            height: 14px;
+            flex-shrink: 0;
+            opacity: 0.7;
+        }
+
+        .meta-status {
+            font-weight: 500;
+        }
     }
 
     .post-editor {


### PR DESCRIPTION
### 问题描述

目前编辑器中标题下方空了一大片，没有任何文章信息展示。用户在编辑时无法快速了解当前文章的基本属性（日期、分类、标签等），需要打开侧边栏设置才能查看。

### 解决方案

1. **新增元数据栏** - 在标题与 Monaco 编辑器之间添加 `post-meta` 区域，展示创建日期、分类、标签和发布状态
2. **调整标题间距** - 标题下方 padding 从 `pb-10` 调整为 `pb-2`，为元数据栏腾出空间
3. **复用现有图标库** - 使用项目已有的 `@heroicons/vue/24/outline` 中的 CalendarIcon、FolderIcon、TagIcon

### 改动范围

- `frontend/src/views/articles/editor/index.vue` - 新增 post-meta 区域及样式，调整标题 padding

### 测试

已在本地验证：新建文章时元数据栏正常显示（日期为今天，无分类/标签时仅显示日期和草稿状态）；编辑已有文章时正确加载日期、分类、标签；修改分类/标签后元数据栏实时更新；发布/草稿状态切换后颜色标签同步变化。
关联 Issue: #22。
分支已推送至 origin/feature/editor-post-meta。

Closes #22