### PR TITLE
feat(article): 文章列表添加日期热力图、分类和标签筛选

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "Vorschau-Dienst konnte nicht gestartet werden",
         "selectLocalImage": "Klicken Sie, um ein lokales Bild auszuwählen",
         "contextMenuTip": "Rechtsklick im Editor öffnet das Kontextmenü",
-        "editorPlaceholder": "Schreiben Sie etwas..."
+        "editorPlaceholder": "Schreiben Sie etwas...",
+        "todayArticles": "Heute",
+        "monthArticles": "Diesen Monat",
+        "allArticles": "Alle Artikel",
+        "allCategories": "Alle Kategorien"
     },
     "tag": {
         "new": "Neu",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "Failed to get preview service",
         "selectLocalImage": "Click to select a local image",
         "contextMenuTip": "Right-click in the editor to open the context menu",
-        "editorPlaceholder": "Write something..."
+        "editorPlaceholder": "Write something...",
+        "todayArticles": "Today",
+        "monthArticles": "This Month",
+        "allArticles": "All Articles",
+        "allCategories": "All Categories"
     },
     "tag": {
         "new": "New",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "Error al obtener el servicio de vista previa",
         "selectLocalImage": "Haz clic para seleccionar una imagen local",
         "contextMenuTip": "Haz clic derecho en el editor para abrir el menú contextual",
-        "editorPlaceholder": "Escribe algo..."
+        "editorPlaceholder": "Escribe algo...",
+        "todayArticles": "Hoy",
+        "monthArticles": "Este Mes",
+        "allArticles": "Todos los Artículos",
+        "allCategories": "Todas las Categorías"
     },
     "tag": {
         "new": "Nuevo",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "Impossible d'obtenir le service d'aperçu",
         "selectLocalImage": "Cliquez pour sélectionner une image locale",
         "contextMenuTip": "Faites un clic droit dans l'éditeur pour ouvrir le menu contextuel",
-        "editorPlaceholder": "Écrivez quelque chose..."
+        "editorPlaceholder": "Écrivez quelque chose...",
+        "todayArticles": "Aujourd'hui",
+        "monthArticles": "Ce Mois",
+        "allArticles": "Tous les Articles",
+        "allCategories": "Toutes les Catégories"
     },
     "tag": {
         "new": "Nouveau",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "Impossibile ottenere il servizio di anteprima",
         "selectLocalImage": "Clicca per selezionare un'immagine locale",
         "contextMenuTip": "Fai clic destro nell'editor per aprire il menu contestuale",
-        "editorPlaceholder": "Scrivi qualcosa..."
+        "editorPlaceholder": "Scrivi qualcosa...",
+        "todayArticles": "Oggi",
+        "monthArticles": "Questo Mese",
+        "allArticles": "Tutti gli Articoli",
+        "allCategories": "Tutte le Categorie"
     },
     "tag": {
         "new": "Nuovo",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "プレビューサービスの取得に失敗しました",
         "selectLocalImage": "クリックしてローカル画像を選択",
         "contextMenuTip": "エディター領域を右クリックするとショートカットメニューが表示されます",
-        "editorPlaceholder": "何か書いてみましょう..."
+        "editorPlaceholder": "何か書いてみましょう...",
+        "todayArticles": "今日の記事",
+        "monthArticles": "今月の記事",
+        "allArticles": "全記事",
+        "allCategories": "全カテゴリ"
     },
     "tag": {
         "new": "新規タグ",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "미리보기 서비스 획득 실패",
         "selectLocalImage": "로컬 이미지를 선택하려면 클릭",
         "contextMenuTip": "편집 영역에서 오른쪽 클릭하면 컨텍스트 메뉴가 나타납니다",
-        "editorPlaceholder": "무엇이든 써보세요..."
+        "editorPlaceholder": "무엇이든 써보세요...",
+        "todayArticles": "오늘 글",
+        "monthArticles": "이번 달 글",
+        "allArticles": "전체 글",
+        "allCategories": "전체 카테고리"
     },
     "tag": {
         "new": "새 태그",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "Falha ao obter o serviço de visualização",
         "selectLocalImage": "Clique para selecionar uma imagem local",
         "contextMenuTip": "Clique com o botão direito no editor para abrir o menu de contexto",
-        "editorPlaceholder": "Escreva algo..."
+        "editorPlaceholder": "Escreva algo...",
+        "todayArticles": "Hoje",
+        "monthArticles": "Este Mês",
+        "allArticles": "Todos os Artigos",
+        "allCategories": "Todas as Categorias"
     },
     "tag": {
         "new": "Nova",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "Не удалось получить сервис предпросмотра",
         "selectLocalImage": "Нажмите, чтобы выбрать локальное изображение",
         "contextMenuTip": "Щёлкните правой кнопкой мыши в редакторе, чтобы открыть контекстное меню",
-        "editorPlaceholder": "Начните писать..."
+        "editorPlaceholder": "Начните писать...",
+        "todayArticles": "Сегодня",
+        "monthArticles": "В этом месяце",
+        "allArticles": "Все статьи",
+        "allCategories": "Все категории"
     },
     "tag": {
         "new": "Новый тег",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -74,7 +74,11 @@
     "previewServiceFailed": "预览服务获取失败",
     "selectLocalImage": "点击选择本地图片",
     "contextMenuTip": "编辑区域右键能弹出快捷菜单哦",
-    "editorPlaceholder": "随便写点什么..."
+        "editorPlaceholder": "随便写点什么...",
+        "todayArticles": "今日文章",
+        "monthArticles": "本月文章",
+        "allArticles": "全部文章",
+        "allCategories": "全部分类"
   },
   "tag": {
     "new": "新标签",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -74,7 +74,11 @@
         "previewServiceFailed": "預覽服務取得失敗",
         "selectLocalImage": "點選選擇本機圖片",
         "contextMenuTip": "在編輯區域按右鍵可開啟快捷選單",
-        "editorPlaceholder": "隨便寫點什麼..."
+        "editorPlaceholder": "隨便寫點什麼...",
+        "todayArticles": "今日文章",
+        "monthArticles": "本月文章",
+        "allArticles": "全部文章",
+        "allCategories": "全部分類"
     },
     "tag": {
         "new": "新增標籤",

--- a/frontend/src/views/articles/list/composables/useArticleList.ts
+++ b/frontend/src/views/articles/list/composables/useArticleList.ts
@@ -1,60 +1,153 @@
-/**
- * 文章列表核心逻辑 Composable
- *
- * 职责：搜索过滤、排序（置顶优先 + 日期降序）、分页计算、页码省略号算法。
- * 从 Articles.vue 中精确迁移，零回归。
- */
-
 import { ref, computed, watch } from 'vue'
 import { useSiteStore } from '@/stores/site'
 import { PAGINATION } from '@/constants/editor'
 import dayjs from 'dayjs'
 import type { IPost } from '@/interfaces/post'
 
+export type TimeFilter = 'all' | 'today' | 'month'
+
 export function useArticleList() {
     const siteStore = useSiteStore()
 
-    // ── 搜索 ──────────────────────────────────────────────
-
     const keyword = ref<string>('')
-
-    // ── 分页 ──────────────────────────────────────────────
+    const selectedTag = ref<string | null>(null)
+    const selectedCategory = ref<string | null>(null)
+    const selectedDate = ref<string | null>(null)
+    const timeFilter = ref<TimeFilter>('all')
 
     const currentPage = ref<number>(1)
     const PAGE_SIZE = PAGINATION.DEFAULT_PAGE_SIZE
 
-    // 搜索关键词变化时重置到第一页
-    watch(keyword, () => {
+    const resetFilters = () => {
         currentPage.value = 1
+    }
+
+    watch(keyword, resetFilters)
+    watch(selectedTag, resetFilters)
+    watch(selectedCategory, resetFilters)
+    watch(selectedDate, resetFilters)
+    watch(timeFilter, resetFilters)
+
+    const setTimeFilter = (filter: TimeFilter) => {
+        timeFilter.value = filter
+        if (filter !== 'all') {
+            selectedTag.value = null
+            selectedCategory.value = null
+            selectedDate.value = null
+        }
+    }
+
+    const setSelectedTag = (tag: string | null) => {
+        selectedTag.value = tag
+        if (tag) {
+            timeFilter.value = 'all'
+            selectedDate.value = null
+            selectedCategory.value = null
+        }
+    }
+
+    const setSelectedCategory = (category: string | null) => {
+        selectedCategory.value = category
+        if (category) {
+            timeFilter.value = 'all'
+            selectedDate.value = null
+            selectedTag.value = null
+        }
+    }
+
+    const setSelectedDate = (date: string | null) => {
+        selectedDate.value = date
+        if (date) {
+            timeFilter.value = 'all'
+            selectedTag.value = null
+            selectedCategory.value = null
+        }
+    }
+
+    const heatmapData = computed(() => {
+        const map: Record<string, number> = {}
+        siteStore.posts.forEach((post: IPost) => {
+            const dateStr = dayjs(post.createdAt).format('YYYY-MM-DD')
+            map[dateStr] = (map[dateStr] || 0) + 1
+        })
+        return map
     })
 
-    // ── 排序 + 过滤后的完整列表 ────────────────────────────
+    const tagStats = computed(() => {
+        const map: Record<string, number> = {}
+        siteStore.posts.forEach((post: IPost) => {
+            (post.tags || []).forEach((tag: string) => {
+                map[tag] = (map[tag] || 0) + 1
+            })
+        })
+        return Object.entries(map)
+            .map(([name, count]) => ({ name, count }))
+            .sort((a, b) => b.count - a.count)
+    })
+
+    const categoryStats = computed(() => {
+        const map: Record<string, number> = {}
+        siteStore.posts.forEach((post: IPost) => {
+            (post.categories || []).forEach((cat: string) => {
+                map[cat] = (map[cat] || 0) + 1
+            })
+        })
+        return Object.entries(map)
+            .map(([name, count]) => ({ name, count }))
+            .sort((a, b) => b.count - a.count)
+    })
+
+    const totalPosts = computed(() => siteStore.posts.length)
+    const todayPosts = computed(() => {
+        const startOfDay = dayjs().startOf('day').valueOf()
+        return siteStore.posts.filter((p: IPost) => dayjs(p.createdAt).valueOf() >= startOfDay).length
+    })
+    const monthPosts = computed(() => {
+        const startOfMonth = dayjs().startOf('month').valueOf()
+        return siteStore.posts.filter((p: IPost) => dayjs(p.createdAt).valueOf() >= startOfMonth).length
+    })
 
     const postList = computed<IPost[]>(() => {
         const search = keyword.value.toLowerCase().trim()
-        let posts: IPost[]
+        let posts = [...siteStore.posts]
 
-        if (!search) {
-            posts = [...siteStore.posts]
-        } else {
-            posts = siteStore.posts.filter((post: IPost) =>
+        if (search) {
+            posts = posts.filter((post: IPost) =>
                 post.title.toLowerCase().includes(search),
             )
         }
 
+        if (selectedDate.value) {
+            posts = posts.filter((post: IPost) =>
+                dayjs(post.createdAt).format('YYYY-MM-DD') === selectedDate.value
+            )
+        } else if (timeFilter.value === 'today') {
+            const startOfDay = dayjs().startOf('day').valueOf()
+            posts = posts.filter((p: IPost) => dayjs(p.createdAt).valueOf() >= startOfDay)
+        } else if (timeFilter.value === 'month') {
+            const startOfMonth = dayjs().startOf('month').valueOf()
+            posts = posts.filter((p: IPost) => dayjs(p.createdAt).valueOf() >= startOfMonth)
+        }
+
+        if (selectedTag.value) {
+            posts = posts.filter((post: IPost) =>
+                (post.tags || []).includes(selectedTag.value!)
+            )
+        }
+
+        if (selectedCategory.value) {
+            posts = posts.filter((post: IPost) =>
+                (post.categories || []).includes(selectedCategory.value!)
+            )
+        }
+
         return posts.sort((a, b) => {
-            // 置顶优先
             const aTop = a.isTop ? 1 : 0
             const bTop = b.isTop ? 1 : 0
-            if (aTop !== bTop) {
-                return bTop - aTop
-            }
-            // 日期降序
+            if (aTop !== bTop) return bTop - aTop
             return dayjs(b.createdAt).valueOf() - dayjs(a.createdAt).valueOf()
         })
     })
-
-    // ── 分页计算 ──────────────────────────────────────────
 
     const totalPages = computed(() => Math.ceil(postList.value.length / PAGE_SIZE))
 
@@ -64,12 +157,6 @@ export function useArticleList() {
         return postList.value.slice(start, end)
     })
 
-    /**
-     * 页码省略号算法
-     * - 始终显示首尾页
-     * - 当前页 ± delta 范围内的页码全部显示
-     * - 超出范围用 -1 (ellipsis) 代替
-     */
     const visiblePages = computed<number[]>(() => {
         const total = totalPages.value
         const current = currentPage.value
@@ -80,9 +167,7 @@ export function useArticleList() {
 
         range.push(1)
         for (let i = current - delta; i <= current + delta; i++) {
-            if (i < total && i > 1) {
-                range.push(i)
-            }
+            if (i < total && i > 1) range.push(i)
         }
         range.push(total)
 
@@ -91,7 +176,7 @@ export function useArticleList() {
                 if (i - l === 2) {
                     rangeWithDots.push(l + 1)
                 } else if (i - l !== 1) {
-                    rangeWithDots.push(-1) // ellipsis sentinel
+                    rangeWithDots.push(-1)
                 }
             }
             rangeWithDots.push(i)
@@ -100,24 +185,33 @@ export function useArticleList() {
         return rangeWithDots
     })
 
-    // ── 分页操作 ──────────────────────────────────────────
-
     const handlePageChanged = (page: number) => {
         currentPage.value = page
         window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return {
-        // 搜索
         keyword,
-        // 分页
+        selectedTag,
+        selectedCategory,
+        selectedDate,
+        timeFilter,
+        setTimeFilter,
+        setSelectedTag,
+        setSelectedCategory,
+        setSelectedDate,
+        heatmapData,
+        tagStats,
+        categoryStats,
+        totalPosts,
+        todayPosts,
+        monthPosts,
         currentPage,
         PAGE_SIZE,
         totalPages,
         currentPostList,
         visiblePages,
         handlePageChanged,
-        // 完整排序列表（供删除等操作使用）
         postList,
     }
 }

--- a/frontend/src/views/articles/list/index.vue
+++ b/frontend/src/views/articles/list/index.vue
@@ -5,44 +5,198 @@
 :keyword="keyword" :selected-count="selectedPost.length" @update:keyword="keyword = $event"
             @delete-selected="deleteModalVisible = true" @new-article="$emit('newArticle')" />
 
-        <!-- Content -->
-        <div class="flex-1 overflow-y-auto px-4 py-6 pb-20">
-            <div class="space-y-3">
-                <ArticleCard
+        <!-- Main Content -->
+        <div class="flex-1 flex overflow-hidden">
+            <!-- Left Sidebar -->
+            <aside class="w-68 flex-shrink-0 border-r border-border flex flex-col overflow-hidden">
+                <div class="p-4 space-y-6 flex-shrink-0">
+                    <ContributionGraph
+:data="heatmapData" :label="t('article.createAt')"
+                        @day-click="setSelectedDate" />
+
+                    <!-- Stats -->
+                    <div class="space-y-1">
+                        <div
+class="flex items-center justify-between text-sm cursor-pointer p-2 rounded-md transition-colors hover:bg-primary/15"
+                            :class="[
+                                timeFilter === 'all'
+                                    ? 'bg-primary/10 text-primary font-medium'
+                                    : 'text-muted-foreground hover:text-foreground'
+                            ]" @click="setTimeFilter('all')">
+                            <span>{{ t('nav.article') }}</span>
+                            <span class="text-xs font-medium opacity-80">{{ totalPosts }}</span>
+                        </div>
+                        <div
+class="flex items-center justify-between text-sm cursor-pointer p-2 rounded-md transition-colors hover:bg-primary/15"
+                            :class="[
+                                timeFilter === 'today'
+                                    ? 'bg-primary/10 text-primary font-medium'
+                                    : 'text-muted-foreground hover:text-foreground'
+                            ]" @click="setTimeFilter('today')">
+                            <span>{{ t('article.todayArticles') }}</span>
+                            <span class="text-xs font-medium opacity-80">{{ todayPosts }}</span>
+                        </div>
+                        <div
+class="flex items-center justify-between text-sm cursor-pointer p-2 rounded-md transition-colors hover:bg-primary/15"
+                            :class="[
+                                timeFilter === 'month'
+                                    ? 'bg-primary/10 text-primary font-medium'
+                                    : 'text-muted-foreground hover:text-foreground'
+                            ]" @click="setTimeFilter('month')">
+                            <span>{{ t('article.monthArticles') }}</span>
+                            <span class="text-xs font-medium opacity-80">{{ monthPosts }}</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Categories Section -->
+                <div
+v-if="categoryStats.length > 0"
+                    class="flex-1 overflow-y-auto p-4 pt-0 min-h-0 overscroll-none">
+                    <div class="space-y-1">
+                        <div
+                            class="flex items-center justify-between px-2 py-2 text-xs text-muted-foreground sticky top-0 bg-background/95 backdrop-blur-sm z-10">
+                            <span>{{ t('nav.category') }}</span>
+                        </div>
+                        <div class="flex flex-wrap gap-1.5 px-2">
+                            <button
+class="inline-flex items-center px-2.5 py-1 text-[11px] rounded-full transition-all duration-200 cursor-pointer border"
+                                :class="[
+                                    selectedCategory === null
+                                        ? 'bg-primary/10 text-primary border-primary/30'
+                                        : 'bg-muted/30 text-muted-foreground border-transparent hover:bg-muted/50 hover:text-foreground'
+                                ]" @click="setSelectedCategory(null)">
+                                {{ t('article.allCategories') }}
+                            </button>
+                            <button
+v-for="cat in categoryStats" :key="cat.name"
+class="inline-flex items-center px-2.5 py-1 text-[11px] rounded-full transition-all duration-200 cursor-pointer border"
+                                :class="[
+                                    selectedCategory === cat.name
+                                        ? 'bg-primary/10 text-primary border-primary/30'
+                                        : 'text-muted-foreground border-transparent hover:bg-muted/50 hover:text-foreground'
+                                ]" @click="setSelectedCategory(cat.name)">
+                                {{ cat.name }} <span class="ml-1 opacity-60">{{ cat.count }}</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Tags Section -->
+                <div
+v-if="tagStats.length > 0"
+                    class="flex-1 overflow-y-auto p-4 pt-0 min-h-0 overscroll-none">
+                    <div class="space-y-1">
+                        <div
+                            class="flex items-center justify-between px-2 py-2 text-xs text-muted-foreground sticky top-0 bg-background/95 backdrop-blur-sm z-10">
+                            <span>{{ t('nav.tag') }}</span>
+                            <span class="text-xs font-medium opacity-80">{{ tagStats.length }}</span>
+                        </div>
+                        <div class="flex flex-wrap gap-1.5 px-2">
+                            <button
+class="inline-flex items-center px-2.5 py-1 text-[11px] rounded-full transition-all duration-200 cursor-pointer border"
+                                :class="[
+                                    selectedTag === null
+                                        ? 'bg-primary/10 text-primary border-primary/30'
+                                        : 'bg-muted/30 text-muted-foreground border-transparent hover:bg-muted/50 hover:text-foreground'
+                                ]" @click="setSelectedTag(null)">
+                                {{ t('article.allArticles') }}
+                            </button>
+                            <button
+v-for="tag in tagStats" :key="tag.name"
+class="inline-flex items-center px-2.5 py-1 text-[11px] rounded-full transition-all duration-200 cursor-pointer border"
+                                :class="[
+                                    selectedTag === tag.name
+                                        ? 'bg-primary/10 text-primary border-primary/30'
+                                        : 'text-muted-foreground border-transparent hover:bg-muted/50 hover:text-foreground'
+                                ]" @click="setSelectedTag(tag.name)">
+                                #{{ tag.name }} <span class="ml-1 opacity-60">{{ tag.count }}</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+
+            <!-- Right Content -->
+            <main class="flex-1 flex flex-col min-w-0 bg-background">
+                <!-- Active Filter Header -->
+                <div v-if="selectedDate || selectedTag || selectedCategory || timeFilter !== 'all'"
+                    class="px-4 pt-4 flex items-center gap-2 flex-wrap">
+                    <div
+v-if="selectedDate" class="flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary rounded-full text-xs border border-primary/20">
+                        <CalendarIcon class="size-3" />
+                        {{ selectedDate }}
+                        <button class="ml-1 hover:text-destructive cursor-pointer" @click="setSelectedDate(null)">
+                            <XMarkIcon class="size-3" />
+                        </button>
+                    </div>
+                    <div
+v-if="selectedCategory" class="flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary rounded-full text-xs border border-primary/20">
+                        <FolderIcon class="size-3" />
+                        {{ selectedCategory }}
+                        <button class="ml-1 hover:text-destructive cursor-pointer" @click="setSelectedCategory(null)">
+                            <XMarkIcon class="size-3" />
+                        </button>
+                    </div>
+                    <div
+v-if="selectedTag" class="flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary rounded-full text-xs border border-primary/20">
+                        <TagIcon class="size-3" />
+                        #{{ selectedTag }}
+                        <button class="ml-1 hover:text-destructive cursor-pointer" @click="setSelectedTag(null)">
+                            <XMarkIcon class="size-3" />
+                        </button>
+                    </div>
+                    <div
+v-if="timeFilter !== 'all' && !selectedDate" class="flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary rounded-full text-xs border border-primary/20">
+                        <ClockIcon class="size-3" />
+                        {{ timeFilter === 'today' ? t('article.todayArticles') : t('article.monthArticles') }}
+                        <button class="ml-1 hover:text-destructive cursor-pointer" @click="setTimeFilter('all')">
+                            <XMarkIcon class="size-3" />
+                        </button>
+                    </div>
+                    <span class="text-xs text-muted-foreground ml-auto">{{ postList.length }} {{ t('nav.article') }}</span>
+                </div>
+
+                <!-- Scrollable Content -->
+                <div class="flex-1 overflow-y-auto px-4 py-4 pb-20">
+                    <div class="space-y-3">
+                        <ArticleCard
 v-for="post in currentPostList" :key="post.fileName" :post="post"
-                    :selected="selectedPost.some(p => p.fileName === post.fileName)" @edit="$emit('editPost', $event)"
-                    @select="onSelectChange" @preview="previewPost" @delete="deleteSinglePost" />
-            </div>
-        </div>
+                            :selected="selectedPost.some(p => p.fileName === post.fileName)" @edit="$emit('editPost', $event)"
+                            @select="onSelectChange" @preview="previewPost" @delete="deleteSinglePost" />
+                    </div>
+                </div>
 
-        <!-- Pagination -->
-        <div v-if="totalPages > 1" class="h-12 py-3 px-4 border-t border-border flex justify-center bg-background">
-            <Pagination :total="postList.length" :items-per-page="PAGE_SIZE" :page="currentPage" :sibling-count="2">
-                <PaginationContent>
-                    <PaginationItem>
-                        <PaginationPrevious
+                <!-- Pagination -->
+                <div v-if="totalPages > 1" class="h-12 py-3 px-4 border-t border-border flex justify-center bg-background">
+                    <Pagination :total="postList.length" :items-per-page="PAGE_SIZE" :page="currentPage" :sibling-count="2">
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious
 :class="{ 'pointer-events-none opacity-50': currentPage === 1 }"
-                            @click="currentPage > 1 && handlePageChanged(currentPage - 1)" />
-                    </PaginationItem>
+                                    @click="currentPage > 1 && handlePageChanged(currentPage - 1)" />
+                            </PaginationItem>
 
-                    <template v-for="page in visiblePages" :key="page">
-                        <PaginationItem v-if="page === -1">
-                            <PaginationEllipsis />
-                        </PaginationItem>
-                        <PaginationLink
+                            <template v-for="page in visiblePages" :key="page">
+                                <PaginationItem v-if="page === -1">
+                                    <PaginationEllipsis />
+                                </PaginationItem>
+                                <PaginationLink
 v-else :value="page" :is-active="currentPage === page"
-                            @click="handlePageChanged(page)">
-                            {{ page }}
-                        </PaginationLink>
-                    </template>
+                                    @click="handlePageChanged(page)">
+                                    {{ page }}
+                                </PaginationLink>
+                            </template>
 
-                    <PaginationItem>
-                        <PaginationNext
+                            <PaginationItem>
+                                <PaginationNext
 :class="{ 'pointer-events-none opacity-50': currentPage === totalPages }"
-                            @click="currentPage < totalPages && handlePageChanged(currentPage + 1)" />
-                    </PaginationItem>
-                </PaginationContent>
-            </Pagination>
+                                    @click="currentPage < totalPages && handlePageChanged(currentPage + 1)" />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                </div>
+            </main>
         </div>
 
         <!-- Delete Confirm Dialog -->
@@ -56,6 +210,7 @@ import { useSiteStore } from '@/stores/site'
 import { BrowserOpenURL } from '@/wailsjs/runtime'
 import { GetPreviewURL } from '@/wailsjs/go/facade/PreviewFacade'
 import { toast } from 'vue-sonner'
+import { CalendarIcon, FolderIcon, TagIcon, ClockIcon, XMarkIcon } from '@heroicons/vue/24/outline'
 
 import {
     Pagination,
@@ -67,6 +222,7 @@ import {
     PaginationPrevious,
 } from '@/components/ui/pagination'
 
+import ContributionGraph from '@/views/memos/components/ContributionGraph.vue'
 import ListHeader from './components/ListHeader.vue'
 import ArticleCard from './components/ArticleCard.vue'
 import DeleteDialog from './components/DeleteDialog.vue'
@@ -84,9 +240,22 @@ defineEmits<{
 const { t } = useI18n()
 const siteStore = useSiteStore()
 
-// ── Composables ─────────────────────────────────────────
 const {
     keyword,
+    selectedTag,
+    selectedCategory,
+    selectedDate,
+    timeFilter,
+    setTimeFilter,
+    setSelectedTag,
+    setSelectedCategory,
+    setSelectedDate,
+    heatmapData,
+    tagStats,
+    categoryStats,
+    totalPosts,
+    todayPosts,
+    monthPosts,
     currentPage,
     PAGE_SIZE,
     totalPages,
@@ -104,7 +273,6 @@ const {
     confirmDelete,
 } = useSelection()
 
-// ── 预览 ────────────────────────────────────────────────
 const previewPost = async (post: IPost) => {
     const { postPath } = siteStore.themeConfig
     try {


### PR DESCRIPTION
### 问题描述

现有文章列表页只有关键词搜索，无法按日期、分类、标签筛选。文章数量增多后定位某篇文章很不方便，而闪念页面已有完善的筛选交互（热力图、标签云、时间快捷筛选），值得参考。

### 解决方案

1. **左侧边栏布局** - 参考闪念页面，在文章列表左侧添加 272px 宽的侧边栏，内含热力图、时间快捷筛选、分类标签云、标签标签云
2. **日期热力图** - 复用闪念页面的 `ContributionGraph` 组件，点击某天按日期筛选文章
3. **时间快捷筛选** - 全部 / 今日 / 本月三个快捷入口，带文章数量统计
4. **分类和标签筛选** - 从文章数据中自动统计分类/标签及其计数，以标签云形式展示，点击即可筛选
5. **筛选互斥逻辑** - 日期、标签、分类、时间范围四种筛选互斥（同闪念页逻辑），切换时自动清除其他筛选条件
6. **筛选条件标签** - 右侧内容区顶部显示当前激活的筛选条件，可单独点击 X 清除

### 改动范围

- `frontend/src/views/articles/list/index.vue` - 添加左侧边栏布局、筛选条件标签
- `frontend/src/views/articles/list/composables/useArticleList.ts` - 新增日期/标签/分类/时间筛选状态和逻辑，热力图/标签/分类统计数据计算
- `frontend/src/locales/*.json` (11个语言文件) - 新增 `todayArticles`、`monthArticles`、`allArticles`、`allCategories` 四个 i18n 键

### 测试

已在本地验证：热力图日历点击某天可按日期筛选；今日/本月快捷筛选正常工作；分类和标签云点击可筛选，计数正确；筛选互斥逻辑正常（选标签清除日期，选日期清除标签等）；筛选条件标签显示正确且可单独清除；分页在筛选后正常工作。
关联 Issue: #21。
分支已推送至 origin/feat/article-filter。

Closes #21