### PR TITLE
fix(tag): 标签和分类更名/删除后级联更新关联文章

### DIFF
--- a/backend/internal/facade/app.go
+++ b/backend/internal/facade/app.go
@@ -17,16 +17,16 @@ import (
 var WailsContext context.Context
 
 type AppServices struct {
-	mu       sync.RWMutex
-	Category *CategoryFacade
-	Post     *PostFacade
-	Menu     *MenuFacade
-	Link     *LinkFacade
-	Tag      *TagFacade
-	Deploy   *DeployFacade
-	Renderer *RendererFacade
-	Theme    *ThemeFacade
-	Setting  *SettingFacade
+	mu         sync.RWMutex
+	Category   *CategoryFacade
+	Post       *PostFacade
+	Menu       *MenuFacade
+	Link       *LinkFacade
+	Tag        *TagFacade
+	Deploy     *DeployFacade
+	Renderer   *RendererFacade
+	Theme      *ThemeFacade
+	Setting    *SettingFacade
 	Comment    *CommentFacade
 	Memo       *MemoFacade
 	Preview    *PreviewFacade
@@ -38,17 +38,17 @@ type AppServices struct {
 	OAuth      *OAuthFacade
 	// Internal services for event/update handling
 	Services struct {
-		Category *service.CategoryService
-		Post     *service.PostService
-		Menu     *service.MenuService
-		Link     *service.LinkService
-		Tag      *service.TagService
-		Deploy   *service.DeployService
-		Renderer *engine.Engine
-		Theme    *service.ThemeService
-		Setting  *service.SettingService
-		Scaffold *service.ScaffoldService
-		Comment  *service.CommentService
+		Category  *service.CategoryService
+		Post      *service.PostService
+		Menu      *service.MenuService
+		Link      *service.LinkService
+		Tag       *service.TagService
+		Deploy    *service.DeployService
+		Renderer  *engine.Engine
+		Theme     *service.ThemeService
+		Setting   *service.SettingService
+		Scaffold  *service.ScaffoldService
+		Comment   *service.CommentService
 		Memo      *service.MemoService
 		Preview   *service.PreviewService
 		CdnUpload *service.CdnUploadService
@@ -95,8 +95,8 @@ func NewAppServices(appDir string, assets embed.FS) *AppServices {
 	oauthService := service.NewOAuthService(credService, cm)
 
 	// 2. Init Services
-	tagService := service.NewTagService(tagRepo)
-	categoryService := service.NewCategoryService(categoryRepo)
+	tagService := service.NewTagService(tagRepo, postRepo)
+	categoryService := service.NewCategoryService(categoryRepo, postRepo)
 	postService := service.NewPostService(postRepo, tagRepo, tagService, categoryService, mediaRepo)
 	menuService := service.NewMenuService(menuRepo)
 	linkService := service.NewLinkService(linkRepo)
@@ -129,15 +129,15 @@ func NewAppServices(appDir string, assets embed.FS) *AppServices {
 
 	// 3. Wrap with Facades
 	return &AppServices{
-		Category: NewCategoryFacade(categoryService),
-		Post:     NewPostFacade(postService),
-		Menu:     NewMenuFacade(menuService),
-		Link:     NewLinkFacade(linkService),
-		Tag:      NewTagFacade(tagService),
-		Deploy:   NewDeployFacade(deployService),
-		Renderer: NewRendererFacade(rendererService),
-		Theme:    NewThemeFacade(themeService),
-		Setting:  NewSettingFacade(settingService, oauthService),
+		Category:   NewCategoryFacade(categoryService, postRepo),
+		Post:       NewPostFacade(postService),
+		Menu:       NewMenuFacade(menuService),
+		Link:       NewLinkFacade(linkService),
+		Tag:        NewTagFacade(tagService, postRepo),
+		Deploy:     NewDeployFacade(deployService),
+		Renderer:   NewRendererFacade(rendererService),
+		Theme:      NewThemeFacade(themeService),
+		Setting:    NewSettingFacade(settingService, oauthService),
 		Comment:    NewCommentFacade(commentService),
 		Memo:       NewMemoFacade(memoService),
 		Preview:    NewPreviewFacade(previewService),
@@ -163,17 +163,17 @@ func NewAppServices(appDir string, assets embed.FS) *AppServices {
 			Preview   *service.PreviewService
 			CdnUpload *service.CdnUploadService
 		}{
-			Category: categoryService,
-			Post:     postService,
-			Menu:     menuService,
-			Link:     linkService,
-			Tag:      tagService,
-			Deploy:   deployService,
-			Renderer: rendererService,
-			Theme:    themeService,
-			Setting:  settingService,
-			Scaffold: scaffoldService,
-			Comment:  commentService,
+			Category:  categoryService,
+			Post:      postService,
+			Menu:      menuService,
+			Link:      linkService,
+			Tag:       tagService,
+			Deploy:    deployService,
+			Renderer:  rendererService,
+			Theme:     themeService,
+			Setting:   settingService,
+			Scaffold:  scaffoldService,
+			Comment:   commentService,
 			Memo:      memoService,
 			Preview:   previewService,
 			CdnUpload: cdnUploadService,

--- a/backend/internal/facade/category_facade.go
+++ b/backend/internal/facade/category_facade.go
@@ -9,10 +9,11 @@ import (
 // CategoryFacade wraps CategoryService
 type CategoryFacade struct {
 	internal *service.CategoryService
+	postRepo domain.PostRepository
 }
 
-func NewCategoryFacade(s *service.CategoryService) *CategoryFacade {
-	return &CategoryFacade{internal: s}
+func NewCategoryFacade(s *service.CategoryService, postRepo domain.PostRepository) *CategoryFacade {
+	return &CategoryFacade{internal: s, postRepo: postRepo}
 }
 
 func (f *CategoryFacade) LoadCategories() ([]domain.Category, error) {
@@ -31,6 +32,12 @@ func (f *CategoryFacade) SaveCategories(categories []domain.Category) error {
 	return f.internal.SaveCategories(ctx, categories)
 }
 
+// CategoryCascadeResult 分类操作返回结果（含更新后的文章列表）
+type CategoryCascadeResult struct {
+	Categories []domain.Category `json:"categories"`
+	Posts      []domain.Post     `json:"posts"`
+}
+
 // CategoryForm 前端提交的分类表单
 type CategoryForm struct {
 	ID          string `json:"id"` // 分类 UUID（新建时为空，更新时必填）
@@ -43,7 +50,7 @@ type CategoryForm struct {
 
 // SaveCategoryFromFrontend 创建或更新分类
 // 若 form.ID 为空则创建新分类；否则按 ID 更新
-func (f *CategoryFacade) SaveCategoryFromFrontend(form CategoryForm) ([]domain.Category, error) {
+func (f *CategoryFacade) SaveCategoryFromFrontend(form CategoryForm) (*CategoryCascadeResult, error) {
 	ctx := WailsContext
 	if ctx == nil {
 		ctx = context.TODO()
@@ -56,16 +63,25 @@ func (f *CategoryFacade) SaveCategoryFromFrontend(form CategoryForm) ([]domain.C
 		Description: form.Description,
 	}
 
-	// originalID 为空 → 新建；非空 → 更新（保持 ID 不变）
 	if err := f.internal.SaveCategory(ctx, newCategory, form.ID); err != nil {
 		return nil, err
 	}
 
-	return f.internal.LoadCategories(ctx)
+	categories, err := f.internal.LoadCategories(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	posts, _, err := f.postRepo.List(ctx, 1, 10000)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CategoryCascadeResult{Categories: categories, Posts: posts}, nil
 }
 
 // DeleteCategoryFromFrontend 按 ID 删除分类，返回更新后的列表
-func (f *CategoryFacade) DeleteCategoryFromFrontend(id string) ([]domain.Category, error) {
+func (f *CategoryFacade) DeleteCategoryFromFrontend(id string) (*CategoryCascadeResult, error) {
 	ctx := WailsContext
 	if ctx == nil {
 		ctx = context.TODO()
@@ -75,7 +91,17 @@ func (f *CategoryFacade) DeleteCategoryFromFrontend(id string) ([]domain.Categor
 		return nil, err
 	}
 
-	return f.internal.LoadCategories(ctx)
+	categories, err := f.internal.LoadCategories(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	posts, _, err := f.postRepo.List(ctx, 1, 10000)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CategoryCascadeResult{Categories: categories, Posts: posts}, nil
 }
 
 // RegisterEvents 注册分类相关事件监听器

--- a/backend/internal/facade/tag_facade.go
+++ b/backend/internal/facade/tag_facade.go
@@ -9,10 +9,11 @@ import (
 // TagFacade wraps TagService
 type TagFacade struct {
 	internal *service.TagService
+	postRepo domain.PostRepository
 }
 
-func NewTagFacade(s *service.TagService) *TagFacade {
-	return &TagFacade{internal: s}
+func NewTagFacade(s *service.TagService, postRepo domain.PostRepository) *TagFacade {
+	return &TagFacade{internal: s, postRepo: postRepo}
 }
 
 func (f *TagFacade) LoadTags() ([]domain.Tag, error) {
@@ -59,33 +60,61 @@ type TagForm struct {
 	OriginalName string `json:"originalName"`
 }
 
+// TagCascadeResult 标签操作返回结果（含更新后的文章列表）
+type TagCascadeResult struct {
+	Tags  []domain.Tag  `json:"tags"`
+	Posts []domain.Post `json:"posts"`
+}
+
 // SaveTagFromFrontend accepts a TagForm directly from frontend
-func (f *TagFacade) SaveTagFromFrontend(form TagForm) ([]domain.Tag, error) {
+func (f *TagFacade) SaveTagFromFrontend(form TagForm) (*TagCascadeResult, error) {
 	newTag := domain.Tag{
 		Name:  form.Name,
 		Slug:  form.Slug,
 		Color: form.Color,
 	}
 
-	// Use SaveTag to handle creation/update
 	if err := f.SaveTag(newTag, form.OriginalName); err != nil {
 		return nil, err
 	}
 
-	// Return updated list
-	return f.LoadTags()
+	tags, err := f.LoadTags()
+	if err != nil {
+		return nil, err
+	}
+
+	posts, _, err := f.postRepo.List(ctx(), 1, 10000)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TagCascadeResult{Tags: tags, Posts: posts}, nil
 }
 
-// DeleteTagFromFrontend accepts a tag name (or slug if logic changed) and returns updated list
-func (f *TagFacade) DeleteTagFromFrontend(name string) ([]domain.Tag, error) {
-	// First, if name is a slug, we might need to find the name, but current logic uses name for deletion
-	// Use DeleteTag method
+// DeleteTagFromFrontend accepts a tag name and returns updated list
+func (f *TagFacade) DeleteTagFromFrontend(name string) (*TagCascadeResult, error) {
 	if err := f.DeleteTag(name); err != nil {
 		return nil, err
 	}
 
-	// Return updated list
-	return f.LoadTags()
+	tags, err := f.LoadTags()
+	if err != nil {
+		return nil, err
+	}
+
+	posts, _, err := f.postRepo.List(ctx(), 1, 10000)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TagCascadeResult{Tags: tags, Posts: posts}, nil
+}
+
+func ctx() context.Context {
+	if WailsContext != nil {
+		return WailsContext
+	}
+	return context.TODO()
 }
 
 // RegisterEvents 注册标签相关事件监听器

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -89,8 +89,8 @@ func initServices(appDir string) *Services {
 	cdnSettingRepo := repository.NewCdnSettingRepository(appDir)
 
 	// Services
-	tagService := service.NewTagService(tagRepo)
-	categoryService := service.NewCategoryService(categoryRepo)
+	tagService := service.NewTagService(tagRepo, postRepo)
+	categoryService := service.NewCategoryService(categoryRepo, postRepo)
 	postService := service.NewPostService(postRepo, tagRepo, tagService, categoryService, mediaRepo)
 	menuService := service.NewMenuService(menuRepo)
 	linkService := service.NewLinkService(linkRepo)

--- a/backend/internal/service/category_service.go
+++ b/backend/internal/service/category_service.go
@@ -7,12 +7,13 @@ import (
 )
 
 type CategoryService struct {
-	repo domain.CategoryRepository
-	mu   sync.RWMutex
+	repo     domain.CategoryRepository
+	postRepo domain.PostRepository
+	mu       sync.RWMutex
 }
 
-func NewCategoryService(repo domain.CategoryRepository) *CategoryService {
-	return &CategoryService{repo: repo}
+func NewCategoryService(repo domain.CategoryRepository, postRepo domain.PostRepository) *CategoryService {
+	return &CategoryService{repo: repo, postRepo: postRepo}
 }
 
 func (s *CategoryService) LoadCategories(ctx context.Context) ([]domain.Category, error) {
@@ -31,22 +32,50 @@ func (s *CategoryService) SaveCategories(ctx context.Context, categories []domai
 // originalID: 若为空则创建新分类；若非空则按 ID 更新
 func (s *CategoryService) SaveCategory(ctx context.Context, category domain.Category, originalID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if originalID == "" {
-		// 新建：Create 会自动生成 UUID
-		return s.repo.Create(ctx, &category)
+		err := s.repo.Create(ctx, &category)
+		s.mu.Unlock()
+		return err
 	}
 
-	// 更新：保持 ID 不变
+	existing, err := s.repo.GetByID(ctx, originalID)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+
+	isRename := existing.Name != category.Name
 	category.ID = originalID
-	return s.repo.Update(ctx, originalID, &category)
+	err = s.repo.Update(ctx, originalID, &category)
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	if isRename {
+		return s.cascadeCategoryRename(ctx, existing.Name, category.Name)
+	}
+	return nil
 }
 
 func (s *CategoryService) DeleteCategory(ctx context.Context, id string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.repo.Delete(ctx, id)
+
+	existing, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	catName := existing.Name
+
+	err = s.repo.Delete(ctx, id)
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	return s.cascadeCategoryDelete(ctx, id, catName)
 }
 
 // GetOrCreateCategory 按名称查找分类，不存在则创建（自动生成 UUID）
@@ -83,4 +112,66 @@ func (s *CategoryService) GetByID(ctx context.Context, id string) (*domain.Categ
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.repo.GetByID(ctx, id)
+}
+
+func (s *CategoryService) cascadeCategoryRename(ctx context.Context, oldName, newName string) error {
+	posts, _, err := s.postRepo.List(ctx, 1, 10000)
+	if err != nil {
+		return err
+	}
+	for i := range posts {
+		changed := false
+		for j, c := range posts[i].Categories {
+			if c == oldName {
+				posts[i].Categories[j] = newName
+				changed = true
+			}
+		}
+		if changed {
+			if err := s.postRepo.Update(ctx, &posts[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *CategoryService) cascadeCategoryDelete(ctx context.Context, categoryID, categoryName string) error {
+	posts, _, err := s.postRepo.List(ctx, 1, 10000)
+	if err != nil {
+		return err
+	}
+	for i := range posts {
+		changed := false
+		var newCats []string
+		for _, c := range posts[i].Categories {
+			if c != categoryName {
+				newCats = append(newCats, c)
+			} else {
+				changed = true
+			}
+		}
+		var newCatIDs []string
+		for _, id := range posts[i].CategoryIDs {
+			if id != categoryID {
+				newCatIDs = append(newCatIDs, id)
+			} else {
+				changed = true
+			}
+		}
+		if changed {
+			posts[i].Categories = newCats
+			if posts[i].Categories == nil {
+				posts[i].Categories = []string{}
+			}
+			posts[i].CategoryIDs = newCatIDs
+			if posts[i].CategoryIDs == nil {
+				posts[i].CategoryIDs = []string{}
+			}
+			if err := s.postRepo.Update(ctx, &posts[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/backend/internal/service/tag_service.go
+++ b/backend/internal/service/tag_service.go
@@ -14,12 +14,13 @@ import (
 )
 
 type TagService struct {
-	repo domain.TagRepository
-	mu   sync.RWMutex
+	repo     domain.TagRepository
+	postRepo domain.PostRepository
+	mu       sync.RWMutex
 }
 
-func NewTagService(repo domain.TagRepository) *TagService {
-	return &TagService{repo: repo}
+func NewTagService(repo domain.TagRepository, postRepo domain.PostRepository) *TagService {
+	return &TagService{repo: repo, postRepo: postRepo}
 }
 
 func (s *TagService) LoadTags(ctx context.Context) ([]domain.Tag, error) {
@@ -31,10 +32,10 @@ func (s *TagService) LoadTags(ctx context.Context) ([]domain.Tag, error) {
 
 func (s *TagService) SaveTag(ctx context.Context, tag domain.Tag, originalName string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	tags, err := s.repo.List(ctx)
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
 
@@ -56,10 +57,19 @@ func (s *TagService) SaveTag(ctx context.Context, tag domain.Tag, originalName s
 	}
 
 	if existing != nil {
+		isRename := originalName != "" && existing.Name != tag.Name
 		existing.Name = tag.Name
 		existing.Slug = tag.Slug
 		existing.Color = tag.Color
-		return s.repo.Update(ctx, existing)
+		if err := s.repo.Update(ctx, existing); err != nil {
+			s.mu.Unlock()
+			return err
+		}
+		s.mu.Unlock()
+		if isRename {
+			return s.cascadeTagRename(ctx, originalName, tag.Name)
+		}
+		return nil
 	}
 
 	// Create new
@@ -67,30 +77,37 @@ func (s *TagService) SaveTag(ctx context.Context, tag domain.Tag, originalName s
 		const alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		id, err := gonanoid.Generate(alphabet, 6)
 		if err != nil {
+			s.mu.Unlock()
 			return err
 		}
 		tag.ID = id
 	}
-	tag.Used = true // Assuming creation means usage in this context
+	tag.Used = true
 
-	return s.repo.Create(ctx, &tag)
+	err = s.repo.Create(ctx, &tag)
+	s.mu.Unlock()
+	return err
 }
 
 func (s *TagService) DeleteTag(ctx context.Context, name string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
-	// We need ID to delete efficiently, but legacy API passed name.
-	// We must find ID first.
 	tags, err := s.repo.List(ctx)
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
 	for _, t := range tags {
 		if t.Name == name {
-			return s.repo.Delete(ctx, t.ID)
+			if err := s.repo.Delete(ctx, t.ID); err != nil {
+				s.mu.Unlock()
+				return err
+			}
+			s.mu.Unlock()
+			return s.cascadeTagDelete(ctx, t.ID, name)
 		}
 	}
+	s.mu.Unlock()
 	return nil
 }
 
@@ -217,6 +234,68 @@ func (s *TagService) generateSlug(name string, existingTags []domain.Tag) string
 	}
 
 	return uniqueSlug
+}
+
+func (s *TagService) cascadeTagRename(ctx context.Context, oldName, newName string) error {
+	posts, _, err := s.postRepo.List(ctx, 1, 10000)
+	if err != nil {
+		return err
+	}
+	for i := range posts {
+		changed := false
+		for j, t := range posts[i].Tags {
+			if t == oldName {
+				posts[i].Tags[j] = newName
+				changed = true
+			}
+		}
+		if changed {
+			if err := s.postRepo.Update(ctx, &posts[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *TagService) cascadeTagDelete(ctx context.Context, tagID, tagName string) error {
+	posts, _, err := s.postRepo.List(ctx, 1, 10000)
+	if err != nil {
+		return err
+	}
+	for i := range posts {
+		changed := false
+		var newTags []string
+		for _, t := range posts[i].Tags {
+			if t != tagName {
+				newTags = append(newTags, t)
+			} else {
+				changed = true
+			}
+		}
+		var newTagIDs []string
+		for _, id := range posts[i].TagIDs {
+			if id != tagID {
+				newTagIDs = append(newTagIDs, id)
+			} else {
+				changed = true
+			}
+		}
+		if changed {
+			posts[i].Tags = newTags
+			if posts[i].Tags == nil {
+				posts[i].Tags = []string{}
+			}
+			posts[i].TagIDs = newTagIDs
+			if posts[i].TagIDs == nil {
+				posts[i].TagIDs = []string{}
+			}
+			if err := s.postRepo.Update(ctx, &posts[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 var TagColors = []string{

--- a/frontend/src/views/categories/composables/useCategory.ts
+++ b/frontend/src/views/categories/composables/useCategory.ts
@@ -112,17 +112,20 @@ export function useCategory() {
         }
 
         try {
-            const categories = await SaveCategoryFromFrontend({
-                id: form.id,        // 空则新建，非空则按 ID 更新
+            const result = await SaveCategoryFromFrontend({
+                id: form.id,
                 name: form.name,
                 slug: form.slug,
                 description: form.description,
-                originalSlug: '',   // 已废弃，保留防能老客户端
+                originalSlug: '',
             })
 
-            if (categories) {
-                siteStore.categories = categories as ICategory[]
-                categoryList.value = [...categories as ICategory[]]
+            if (result) {
+                siteStore.categories = result.categories as ICategory[]
+                categoryList.value = [...result.categories as ICategory[]]
+                if (result.posts) {
+                    siteStore.posts = result.posts
+                }
                 toast.success(t('category.saved'))
                 visible.value = false
             }
@@ -139,10 +142,13 @@ export function useCategory() {
     const handleDelete = async () => {
         if (categoryToDelete.value) {
             try {
-                const categories = await DeleteCategoryFromFrontend(categoryToDelete.value)
-                if (categories) {
-                    siteStore.categories = categories as ICategory[]
-                    categoryList.value = [...categories as ICategory[]]
+                const result = await DeleteCategoryFromFrontend(categoryToDelete.value)
+                if (result) {
+                    siteStore.categories = result.categories as ICategory[]
+                    categoryList.value = [...result.categories as ICategory[]]
+                    if (result.posts) {
+                        siteStore.posts = result.posts
+                    }
                     toast.success(t('category.deleted'))
                 }
             } catch (e: any) {

--- a/frontend/src/views/tags/composables/useTag.ts
+++ b/frontend/src/views/tags/composables/useTag.ts
@@ -130,11 +130,14 @@ export function useTag() {
                 color: form.color || '',
                 originalName: form.originalName || '',
             })
-            const newTags = await SaveTagFromFrontend(tagForm)
+            const result = await SaveTagFromFrontend(tagForm)
 
-            if (newTags) {
-                siteStore.tags = newTags
-                tagList.value = [...newTags]
+            if (result) {
+                siteStore.tags = result.tags
+                tagList.value = [...result.tags]
+                if (result.posts) {
+                    siteStore.posts = result.posts
+                }
                 toast.success(t('tag.saved'))
                 visible.value = false
             }
@@ -153,10 +156,13 @@ export function useTag() {
             const tag = siteStore.tags.find(t => t.slug === tagToDelete.value)
             if (tag) {
                 try {
-                    const newTags = await DeleteTagFromFrontend(tag.name)
-                    if (newTags) {
-                        siteStore.tags = newTags
-                        tagList.value = [...newTags]
+                    const result = await DeleteTagFromFrontend(tag.name)
+                    if (result) {
+                        siteStore.tags = result.tags
+                        tagList.value = [...result.tags]
+                        if (result.posts) {
+                            siteStore.posts = result.posts
+                        }
                         toast.success(t('tag.deleted'))
                     }
                 } catch (e: any) {


### PR DESCRIPTION
### 问题描述

标签更名或删除后，文章中原有的标签名/标签ID仍保留，不会随标签变化而更新。分类同理——更名或删除分类后，文章中的分类名/分类ID不会同步变更，需手动逐篇修改。

### 解决方案

1. **后端：TagService 级联逻辑** - `SaveTag` 在检测到标签更名时，遍历所有文章将其 `Tags[]` 中的旧名称替换为新名称；`DeleteTag` 在删除标签后，遍历所有文章移除该标签的名称和ID
2. **后端：CategoryService 级联逻辑** - `SaveCategory` 在检测到分类更名时，遍历所有文章将其 `Categories[]` 中的旧名称替换为新名称；`DeleteCategory` 在删除分类后，遍历所有文章移除该分类的名称和ID
3. **后端：Facade 返回值扩展** - `TagFacade` 的 `SaveTagFromFrontend`/`DeleteTagFromFrontend` 和 `CategoryFacade` 的 `SaveCategoryFromFrontend`/`DeleteCategoryFromFrontend` 新增返回更新后的文章列表（`TagCascadeResult`/`CategoryCascadeResult`），包含 tags/categories + posts
4. **前端：同步更新 posts** - 标签/分类保存/删除操作完成后，不仅更新 `siteStore.tags`/`categories`，也更新 `siteStore.posts`
5. **互斥锁安全** - 级联操作（写 Post 文件）在 Service 互斥锁释放后执行，避免与 PostRepository 的锁死锁

### 改动范围

- `backend/internal/service/tag_service.go` - 新增 `cascadeTagRename`、`cascadeTagDelete` 方法，`NewTagService` 注入 `PostRepository`
- `backend/internal/service/category_service.go` - 新增 `cascadeCategoryRename`、`cascadeCategoryDelete` 方法，`NewCategoryService` 注入 `PostRepository`
- `backend/internal/facade/tag_facade.go` - 新增 `TagCascadeResult` DTO，Facade 方法返回更新后的文章列表
- `backend/internal/facade/category_facade.go` - 新增 `CategoryCascadeResult` DTO，Facade 方法返回更新后的文章列表
- `backend/internal/facade/app.go` - 更新依赖注入，传入 `postRepo`
- `backend/internal/mcp/server.go` - 同步更新依赖注入
- `frontend/src/views/tags/composables/useTag.ts` - 处理新返回格式，同步更新 `siteStore.posts`
- `frontend/src/views/categories/composables/useCategory.ts` - 同上

### 测试

已在本地验证 Go 编译通过（`go build ./...`），前端编译通过（`vite build` + `vue-tsc --noEmit`）。标签/分类更名时关联文章自动更新，删除时关联文章自动移除该标签/分类。
关联 Issue: #19。
分支已推送至 origin/fix/issue-19。

Closes #19