### PR TITLE
fix(render): 删除文章后清理旧输出文件并触发重新渲染

### DIFF
--- a/backend/internal/engine/engine.go
+++ b/backend/internal/engine/engine.go
@@ -159,6 +159,9 @@ func (s *Engine) RenderAll(ctx context.Context) error {
 	}
 
 	buildDir := filepath.Join(s.appDir, DirOutput)
+
+	// 清理旧的输出文件，避免已删除的文章残留 HTML
+	_ = os.RemoveAll(buildDir)
 	_ = os.MkdirAll(buildDir, 0755)
 
 	var errs error

--- a/frontend/src/views/articles/list/composables/useSelection.ts
+++ b/frontend/src/views/articles/list/composables/useSelection.ts
@@ -63,6 +63,7 @@ export function useSelection() {
 
             if (updatedPosts) {
                 siteStore.posts = updatedPosts
+                EventsEmit('app-site-reload')
                 toast.success(t('article.delete'))
                 selectedPost.value = []
             }


### PR DESCRIPTION
### 问题描述

删除文章后，`output` 目录下仍残留该文章的 HTML 页面，导致部署后仍可访问已删除的文章。修改主题模板后，output 中的 HTML 也不会自动同步更新。

### 解决方案

1. **清理 output 目录** - 在 `Engine.RenderAll()` 开头添加 `os.RemoveAll(buildDir)` 再重建，确保每次渲染时旧文件被清除，不再有残留的已删除文章 HTML
2. **删除文章后触发重新渲染** - 前端 `confirmDelete` 成功后发出 `app-site-reload` 事件，触发全站重新渲染，使 output 目录即时同步

### 改动范围

- `backend/internal/engine/engine.go` - RenderAll 开始前清理 output 目录
- `frontend/src/views/articles/list/composables/useSelection.ts` - 删除文章成功后触发 `app-site-reload`

### 测试

创建文章 → 触发预览确认 output 中有该文章目录 → 删除文章 → 确认 output 中对应目录已被清除。
关联 Issue: #26。
分支已推送至 origin/fix/issue-26。

Closes #26