### PR TITLE
fix(render): renderPaginated 用 defer 归还 bufferPool，panic 安全

### DIFF
--- a/backend/internal/engine/page_renderer.go
+++ b/backend/internal/engine/page_renderer.go
@@ -180,12 +180,15 @@ func (r *PageRenderer) renderPaginated(ctx context.Context, cfg paginatedRenderC
 			}
 		}
 
-		buf := bufferPool.Get().(*bytes.Buffer)
-		buf.Reset()
-		buf.WriteString(html)
-		writeErr := r.manifest.WriteFile(filepath.Join(outDir, FileIndexHTML), buf.Bytes(), 0644)
-		bufferPool.Put(buf)
-		if writeErr != nil {
+		// 用 IIFE 限定 buf 的作用域，让 defer bufferPool.Put 在每一页写完后立即触发，
+		// panic 安全且与 RenderPost/RenderTags/RenderFriends 等其他位置风格一致。
+		if writeErr := func() error {
+			buf := bufferPool.Get().(*bytes.Buffer)
+			defer bufferPool.Put(buf)
+			buf.Reset()
+			buf.WriteString(html)
+			return r.manifest.WriteFile(filepath.Join(outDir, FileIndexHTML), buf.Bytes(), 0644)
+		}(); writeErr != nil {
 			return writeErr
 		}
 	}


### PR DESCRIPTION
## Summary

- `PageRenderer.renderPaginated` 每写一页的 `bytes.Buffer` 是从 `bufferPool` 借出来的，原来直接在最后一行 `bufferPool.Put(buf)`：一旦 `WriteFile` 中途 panic，这一页的 buffer 就不会归还，后续请求只能重新 `make`，长尾场景下池容量会抖动。
- 改用 IIFE 包裹 `Get/Reset/Write/WriteFile`，通过 `defer bufferPool.Put(buf)` 在每一页结束（无论正常返回还是 panic）都归还。
- 风格与同文件 `RenderPost` / `RenderTags` / `RenderFriends` / `RenderMemos` / `Render404` 等其他 buffer 使用点一致。

Fixes #64

## Test plan

- [x] `go build ./...`
- [ ] 手动跑一次带分页的站点生成，确认输出与之前一致
- [ ] 回归：分页页面无重复写入 / 丢页

🤖 Generated with [Claude Code](https://claude.com/claude-code)