### PR TITLE
fix(engine): 兜底标签/分类 Slug 做 URL-safe 处理 (#59)

### DIFF
--- a/backend/internal/engine/data_builder.go
+++ b/backend/internal/engine/data_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -196,12 +197,18 @@ func (b *TemplateDataBuilder) Build(ctx context.Context, posts []domain.Post, co
 			}
 		}
 	}
-	// 兜底：tagRepo 中不存在但文章中使用的标签，追加到末尾
+	// 兜底：tagRepo 中不存在但文章中使用的标签，追加到末尾。
+	// 原始 Name 可能含中文/空格/非法 URL 字符，走 SlugifyName（拼音 + slug.Make）
+	// 生成可读的 slug；完全无可用 ASCII 字符时退回 url.PathEscape 保证 URL 合法且稳定。
 	for name, count := range tagCountMap {
+		s := utils.SlugifyName(name)
+		if s == "" {
+			s = url.PathEscape(name)
+		}
 		allTags = append(allTags, template.TagView{
 			Name:  name,
-			Slug:  name,
-			Link:  "/" + tagPath + "/" + name + "/",
+			Slug:  s,
+			Link:  "/" + tagPath + "/" + s + "/",
 			Count: count,
 		})
 	}
@@ -419,10 +426,18 @@ func (b *TemplateDataBuilder) convertPost(post domain.Post, config domain.ThemeC
 	var tags []template.TagView
 	var tagNames []string
 	for _, tag := range post.Tags {
-		tagSlug := tag
+		tagSlug := ""
 		if tagByName != nil {
 			if t, ok := tagByName[tag]; ok {
 				tagSlug = t.Slug
+			}
+		}
+		// 兜底：Name 可能含中文/空格/非法 URL 字符，做与 all-tags 列表一致的
+		// slugify（拼音 + slug.Make），保证视图层生成合法 URL。
+		if tagSlug == "" {
+			tagSlug = utils.SlugifyName(tag)
+			if tagSlug == "" {
+				tagSlug = url.PathEscape(tag)
 			}
 		}
 		tagView := template.TagView{
@@ -456,10 +471,17 @@ func (b *TemplateDataBuilder) convertPost(post domain.Post, config domain.ThemeC
 	} else {
 		// 向后兼容：老文章无 CategoryIDs，回退使用名称字符串
 		for _, category := range post.Categories {
-			slug := category
+			slug := ""
 			if categoryByName != nil {
 				if cat, ok := categoryByName[category]; ok {
 					slug = cat.Slug
+				}
+			}
+			// 兜底：Name 可能含中文/空格/非法 URL 字符，走 slugify 保证 URL 合法。
+			if slug == "" {
+				slug = utils.SlugifyName(category)
+				if slug == "" {
+					slug = url.PathEscape(category)
 				}
 			}
 			categories = append(categories, template.CategoryView{

--- a/backend/internal/service/tag_service.go
+++ b/backend/internal/service/tag_service.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 	"gridea-pro/backend/internal/domain"
+	"gridea-pro/backend/internal/utils"
 	"strings"
 	"sync"
-	"unicode"
 
-	"github.com/gosimple/slug"
 	gonanoid "github.com/matoous/go-nanoid/v2"
-	"github.com/mozillazg/go-pinyin"
 )
 
 type TagService struct {
@@ -174,48 +172,12 @@ func (s *TagService) GetOrCreateTag(ctx context.Context, name string) (domain.Ta
 }
 
 func (s *TagService) generateSlug(name string, existingTags []domain.Tag) string {
-	// 1. Convert to Pinyin if it contains Chinese
-	pinyinArgs := pinyin.NewArgs()
-	pinyinArgs.Fallback = func(r rune, a pinyin.Args) []string {
-		return []string{string(r)}
-	}
-
-	// Check if string contains chinese
-	// Simple check: iterate runes
-	hasChinese := false
-	for _, r := range name {
-		if unicode.Is(unicode.Han, r) {
-			hasChinese = true
-			break
-		}
-	}
-
-	var preSlug string
-	if hasChinese {
-		// Pinyin conversion
-		// "测试" -> [[ce], [shi]]
-		pyRows := pinyin.Pinyin(name, pinyinArgs)
-		var parts []string
-		for _, row := range pyRows {
-			if len(row) > 0 {
-				parts = append(parts, row[0])
-			}
-		}
-		preSlug = strings.Join(parts, "-")
-	} else {
-		preSlug = name
-	}
-
-	// 2. Slugify (handling special chars, lower case)
-	finalSlug := slug.Make(preSlug)
+	finalSlug := utils.SlugifyName(name)
 	if finalSlug == "" {
-		// Fallback for purely special chars or empty slug result
 		const alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		finalSlug, _ = gonanoid.Generate(alphabet, 6)
 	}
 
-	// 3. Handle Duplicates
-	// Check against existing slugs
 	uniqueSlug := finalSlug
 	counter := 1
 	for {

--- a/backend/internal/utils/slug.go
+++ b/backend/internal/utils/slug.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/gosimple/slug"
+	"github.com/mozillazg/go-pinyin"
+)
+
+// SlugifyName 将人类可读的名称（可能含中文、标点、空格等）转成 URL-safe 的 slug。
+//
+// 处理流程：
+//  1. 逐 rune 扫描：中文字符替换为「空格 + 拼音 + 空格」，其余字符原样保留
+//  2. 将中间字符串交给 gosimple/slug.Make 做 ASCII 规范化
+//     （小写、去特殊字符、连字符合并）
+//
+// 混排场景（"hello 世界"）也能正确得到 "hello-shi-jie" 而不是把英文逐字母拆散。
+//
+// 若结果为空串（例如纯 emoji / 符号名），返回空串由调用方决定兜底策略：
+//   - 需要持久化时建议用 nanoid 保证唯一
+//   - 仅做视图展示时建议用 url.PathEscape(name) 保证确定性 URL
+func SlugifyName(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	pinyinArgs := pinyin.NewArgs()
+
+	var b strings.Builder
+	b.Grow(len(name) * 2)
+	for _, r := range name {
+		if unicode.Is(unicode.Han, r) {
+			rows := pinyin.Pinyin(string(r), pinyinArgs)
+			if len(rows) > 0 && len(rows[0]) > 0 {
+				b.WriteByte(' ')
+				b.WriteString(rows[0][0])
+				b.WriteByte(' ')
+			}
+		} else {
+			b.WriteRune(r)
+		}
+	}
+
+	return slug.Make(b.String())
+}

--- a/backend/internal/utils/slug_test.go
+++ b/backend/internal/utils/slug_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import "testing"
+
+func TestSlugifyName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// 英文 / 数字
+		{"english_basic", "Hello World", "hello-world"},
+		{"english_punct", "Hello, World!", "hello-world"},
+		{"mixed_case", "HelloWorld", "helloworld"},
+		{"numbers", "Go 1.22", "go-1-22"},
+		{"hyphen_passthrough", "abc-def", "abc-def"},
+
+		// 中文 → 拼音
+		{"chinese_simple", "测试", "ce-shi"},
+		{"chinese_longer", "你好世界", "ni-hao-shi-jie"},
+		{"chinese_mixed", "hello 世界", "hello-shi-jie"},
+
+		// 非法 URL 字符被清理
+		{"slash", "a/b/c", "a-b-c"},
+		{"hash", "a#b", "a-b"},
+		{"question", "a?b", "a-b"},
+		{"space_only_inside", "foo  bar", "foo-bar"},
+
+		// 空 / 无有效字符（期望空串，由调用方决定兜底）
+		{"empty", "", ""},
+		{"pure_emoji", "🌟✨", ""},
+		{"pure_symbol", "!!!", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SlugifyName(tt.input)
+			if got != tt.want {
+				t.Errorf("SlugifyName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

修复 #59：TemplateDataBuilder 在若干兜底路径中直接把 Tag / Category 的 Name 当成 Slug 使用，Name 含中文 / 空格 / 非法 URL 字符（\`&?#/\` 等）时会生成不规范甚至跨页面的链接。

## 涉及位置

扫描后发现同一 bug 模式出现在三处（issue 原报告只覆盖了第一处）：

1. \`TemplateDataBuilder.Build\` — all-tags 列表里"文章用到但 tagRepo 未登记的标签"的兜底路径
2. \`convertPost\` — post 内 tag 转换，\`tagByName\` 未命中时
3. \`convertPost\` — post 内 category 转换的向后兼容路径（老文章没有 \`CategoryIDs\` 时按名称回退）

## 修复方案

- 抽取公共工具 \`utils.SlugifyName\`（拼音 + \`gosimple/slug.Make\`），覆盖中英混排、纯符号、空串等边界，附单测
- 三处兜底统一走 \`SlugifyName\`；返回空串（纯 emoji / 符号）时退回 \`url.PathEscape\` 保证 URL 合法且确定性（不用 nanoid，避免每次渲染 slug 漂移）
- \`TagService.generateSlug\` 改为复用 \`utils.SlugifyName\`，维持原有去重 (\`-1\`/\`-2\` 后缀) 与 nanoid 兜底（因为是持久化路径）

## 未包含 / 后续讨论

\`convertPost\` 中 \`CategoryIDs\` 指向的 ID 在 \`categoryByID\` 里找不到时（分类被删除后仍被引用），当前把 \`catID\`（nanoid）同时当 Name 和 Slug 展示。这是一个 UX bug（前台会看到形如 \`V1StGXR8\` 的"分类名"），但并非 URL 合法性问题 —— 建议在独立 issue 里讨论（是否跳过、显示占位文本 \"已删除分类\"、还是触发级联清理）。

## Test plan

- [x] \`go test ./backend/internal/utils/...\` — 15 个 slug case 全绿，含中文 / 中英混排 / 纯符号 / emoji / 空串
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 创建中文标签的文章、deploy，确认生成的 tag/category 链接可正常打开
- [ ] 人工编辑 JSON 制造"孤儿标签"（post 引用但 tagRepo 不存在），渲染应得到拼音 slug 而非中文

🤖 Generated with [Claude Code](https://claude.com/claude-code)