### PR TITLE
fix(update): pickAsset 收紧后缀白名单，避免非二进制附件误选 (#57)

### DIFF
--- a/backend/internal/facade/update_facade.go
+++ b/backend/internal/facade/update_facade.go
@@ -352,8 +352,45 @@ func (f *UpdateFacade) emitError(err error) {
 	})
 }
 
+// extRule 描述合法发布包后缀及其自更新优先级。
+type extRule struct {
+	ext string
+	pri int
+}
+
+// binaryAssetRules 定义可作为自更新候选的 asset 后缀白名单。
+// 按长度降序排列，避免 .tar.gz 被更短的 .gz 抢先匹配（预留扩展）。
+// 优先级：.zip/.exe/.AppImage 这类可直接替换主程序的打包 > .dmg/.msi 安装器 > .deb/.rpm 包管理格式。
+var binaryAssetRules = []extRule{
+	{".AppImage", 4},
+	{".tar.gz", 3},
+	{".tar.xz", 2},
+	{".zip", 4},
+	{".exe", 4},
+	{".dmg", 3},
+	{".msi", 3},
+	{".deb", 1},
+	{".rpm", 1},
+}
+
+// matchAssetExt 返回 name 匹配的二进制后缀及其优先级；未命中返回空串与 0。
+func matchAssetExt(name string) (string, int, bool) {
+	lower := strings.ToLower(name)
+	for _, r := range binaryAssetRules {
+		if strings.HasSuffix(lower, strings.ToLower(r.ext)) {
+			return r.ext, r.pri, true
+		}
+	}
+	return "", 0, false
+}
+
 // pickAsset 按当前 GOOS/GOARCH 找到匹配的 asset。
-// 命名约定宽松：只要同时包含平台和架构关键字即可命中。
+//
+// 匹配条件：
+//  1. 文件名（lowercase）需包含当前平台关键字
+//  2. 文件名后缀必须在二进制发布包白名单内（避免 changelog.md / notes.txt 等附件被误选）
+//  3. 当指定平台有架构关键字集时，未带架构关键字的包允许匹配但权重降一档
+//  4. setup/installer 命名降权，避免自更新流程去拉交互式安装器
 func pickAsset(assets []githubAsset, goos, goarch string) *githubAsset {
 	osKeys := map[string][]string{
 		"darwin":  {"darwin", "mac", "macos", "osx"},
@@ -364,14 +401,6 @@ func pickAsset(assets []githubAsset, goos, goarch string) *githubAsset {
 		"amd64": {"amd64", "x86_64", "x64", "intel"},
 		"arm64": {"arm64", "aarch64", "apple"},
 	}
-	// 扩展名优先级（同平台匹配多个时取优先级高的）
-	// macOS 自更新优先 .zip（installer 可直接解压 .app），.dmg 留给首次下载
-	// Windows 自更新优先便携 .exe（selfupdate 可直接替换），.msi 安装器吃不下
-	extPriority := map[string]int{
-		".zip": 4, ".dmg": 3, // macOS
-		".exe": 4, ".msi": 3, // windows
-		".AppImage": 4, ".tar.gz": 3, ".tar.xz": 2, // linux
-	}
 
 	var best *githubAsset
 	bestPri := -1
@@ -381,15 +410,13 @@ func pickAsset(assets []githubAsset, goos, goarch string) *githubAsset {
 		if !containsAny(name, osKeys[goos]) {
 			continue
 		}
-		if keys, ok := archKeys[goarch]; ok && !containsAny(name, keys) {
-			// 没带架构关键字的通用包也允许，但优先级降一档
+		_, pri, ok := matchAssetExt(name)
+		if !ok {
+			continue
 		}
-		pri := 0
-		for ext, p := range extPriority {
-			if strings.HasSuffix(name, strings.ToLower(ext)) {
-				pri = p
-				break
-			}
+		// 没带架构关键字的通用包允许匹配，但权重降一档，优先选明确匹配架构的包
+		if keys, ok := archKeys[goarch]; ok && !containsAny(name, keys) {
+			pri--
 		}
 		// 安装器类资源自更新无法直接替换二进制，降权避免被 selfupdate 选中
 		if strings.Contains(name, "setup") || strings.Contains(name, "installer") {

--- a/backend/internal/facade/update_facade_test.go
+++ b/backend/internal/facade/update_facade_test.go
@@ -1,0 +1,163 @@
+package facade
+
+import "testing"
+
+func mkAssets(names ...string) []githubAsset {
+	out := make([]githubAsset, len(names))
+	for i, n := range names {
+		out[i] = githubAsset{Name: n, DownloadURL: "https://example.com/" + n, Size: 1024}
+	}
+	return out
+}
+
+func TestPickAsset_BinaryWhitelist(t *testing.T) {
+	tests := []struct {
+		name    string
+		assets  []githubAsset
+		goos    string
+		goarch  string
+		wantHit string // 期望的 asset name；"" 表示 nil
+	}{
+		{
+			name:    "macos_arm64_zip_wins",
+			assets:  mkAssets("Gridea-Pro-1.0.0-darwin-arm64.zip", "Gridea-Pro-1.0.0-darwin-arm64.dmg"),
+			goos:    "darwin",
+			goarch:  "arm64",
+			wantHit: "Gridea-Pro-1.0.0-darwin-arm64.zip",
+		},
+		{
+			name:    "windows_amd64_exe_wins_over_msi",
+			assets:  mkAssets("Gridea-Pro-1.0.0-windows-amd64.exe", "Gridea-Pro-1.0.0-windows-amd64.msi"),
+			goos:    "windows",
+			goarch:  "amd64",
+			wantHit: "Gridea-Pro-1.0.0-windows-amd64.exe",
+		},
+		{
+			name:    "linux_amd64_appimage_wins",
+			assets:  mkAssets("Gridea-Pro-1.0.0-linux-amd64.AppImage", "Gridea-Pro-1.0.0-linux-amd64.tar.gz"),
+			goos:    "linux",
+			goarch:  "amd64",
+			wantHit: "Gridea-Pro-1.0.0-linux-amd64.AppImage",
+		},
+		{
+			// 核心修复：含平台关键字的非二进制附件（.md/.txt/.json）必须被忽略
+			name: "markdown_with_macos_keyword_ignored",
+			assets: mkAssets(
+				"changelog-macos.md",
+				"Gridea-Pro-1.0.0-darwin-arm64.zip",
+			),
+			goos:    "darwin",
+			goarch:  "arm64",
+			wantHit: "Gridea-Pro-1.0.0-darwin-arm64.zip",
+		},
+		{
+			// 仅有非二进制附件时，pickAsset 应返回 nil 而非错选 .md
+			name: "only_markdown_returns_nil",
+			assets: mkAssets(
+				"release-notes-macos.md",
+				"install-guide-linux.txt",
+				"build-manifest-windows.json",
+			),
+			goos:    "darwin",
+			goarch:  "arm64",
+			wantHit: "",
+		},
+		{
+			// setup/installer 命名降权，便携 exe 胜出
+			name: "portable_exe_beats_installer_exe",
+			assets: mkAssets(
+				"Gridea-Pro-1.0.0-windows-amd64-setup.exe",
+				"Gridea-Pro-1.0.0-windows-amd64.exe",
+			),
+			goos:    "windows",
+			goarch:  "amd64",
+			wantHit: "Gridea-Pro-1.0.0-windows-amd64.exe",
+		},
+		{
+			// 架构未指定：通用包允许命中但权重降一档，优先匹配明确架构的
+			name: "arch_specific_beats_generic",
+			assets: mkAssets(
+				"Gridea-Pro-1.0.0-darwin.zip",          // 没带架构
+				"Gridea-Pro-1.0.0-darwin-arm64.zip",    // 明确 arm64
+			),
+			goos:    "darwin",
+			goarch:  "arm64",
+			wantHit: "Gridea-Pro-1.0.0-darwin-arm64.zip",
+		},
+		{
+			// 没有当前平台的 asset 时返回 nil
+			name:    "no_match_returns_nil",
+			assets:  mkAssets("Gridea-Pro-1.0.0-linux-amd64.AppImage"),
+			goos:    "darwin",
+			goarch:  "arm64",
+			wantHit: "",
+		},
+		{
+			// deb/rpm 虽在白名单但优先级较低，zip 应胜出
+			name: "zip_beats_deb",
+			assets: mkAssets(
+				"gridea-pro_1.0.0_linux_amd64.deb",
+				"Gridea-Pro-1.0.0-linux-amd64.tar.gz",
+			),
+			goos:    "linux",
+			goarch:  "amd64",
+			wantHit: "Gridea-Pro-1.0.0-linux-amd64.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickAsset(tt.assets, tt.goos, tt.goarch)
+			if tt.wantHit == "" {
+				if got != nil {
+					t.Errorf("pickAsset returned %q, want nil", got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("pickAsset returned nil, want %q", tt.wantHit)
+			}
+			if got.Name != tt.wantHit {
+				t.Errorf("pickAsset returned %q, want %q", got.Name, tt.wantHit)
+			}
+		})
+	}
+}
+
+func TestMatchAssetExt(t *testing.T) {
+	tests := []struct {
+		name     string
+		want     string
+		priGT    int  // priority must be > this
+		wantHit  bool
+	}{
+		{"app-1.0.0.AppImage", ".AppImage", 0, true},
+		{"app-1.0.0.tar.gz", ".tar.gz", 0, true},
+		{"app-1.0.0.tar.xz", ".tar.xz", 0, true},
+		{"app-1.0.0-darwin-arm64.zip", ".zip", 0, true},
+		{"app-1.0.0-darwin.dmg", ".dmg", 0, true},
+		{"app-1.0.0-windows.exe", ".exe", 0, true},
+		{"app-1.0.0-windows.msi", ".msi", 0, true},
+		{"app.deb", ".deb", 0, true},
+		{"app.rpm", ".rpm", 0, true},
+		{"changelog.md", "", -1, false},
+		{"notes.txt", "", -1, false},
+		{"manifest.json", "", -1, false},
+		{"release.yaml", "", -1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ext, pri, ok := matchAssetExt(tt.name)
+			if ok != tt.wantHit {
+				t.Errorf("matchAssetExt(%q) hit = %v, want %v", tt.name, ok, tt.wantHit)
+			}
+			if ok && ext != tt.want {
+				t.Errorf("matchAssetExt(%q) ext = %q, want %q", tt.name, ext, tt.want)
+			}
+			if ok && pri <= tt.priGT {
+				t.Errorf("matchAssetExt(%q) priority = %d, want > %d", tt.name, pri, tt.priGT)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

修复 #57：\`pickAsset\` 仅按"文件名含平台关键字"筛选即可进入打分，release 中若出现含平台关键字的非二进制附件（如 \`changelog-macos.md\` / \`install-notes-linux.txt\`），在极端情况下可能被选为自更新包。

## 修复方案

- 抽取 \`binaryAssetRules\` 白名单：\`.zip\` / \`.dmg\` / \`.exe\` / \`.msi\` / \`.AppImage\` / \`.tar.gz\` / \`.tar.xz\` / \`.deb\` / \`.rpm\`，按长度降序排列避免 \`.tar.gz\` 被短后缀抢匹配
- \`pickAsset\` 里未命中白名单的 asset 直接跳过，不进入打分
- 把"没带架构关键字的通用包降权一档"从注释里落到实际代码（原注释说降档但未实现）
- 新增单测，覆盖主流 asset 胜出、markdown 附件忽略、installer 降权、架构明确 vs 通用、deb/rpm 低优先、无匹配返回 nil 等场景

## 未选的替代方案

issue 里另一个方案是用正则 \`^Gridea-Pro-[\\d.]+-(\\w+)-(\\w+)\\.(\\w+)$\` 强命名约定，更严格但对历史 release 兼容性差；白名单方案零配置、足够防御。

## Test plan

- [x] \`go test ./backend/internal/facade/...\` — 9 个 pickAsset case + 13 个 matchAssetExt case 全绿
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 下个 release 保留现有命名格式，观察线上自更新是否正常选包（白名单覆盖了当前所有产出格式）

🤖 Generated with [Claude Code](https://claude.com/claude-code)