### PR TITLE
fix(engine): 首页降级补齐分页，文章降级区分专属模板 (#62)

### DIFF
--- a/backend/internal/engine/page_renderer.go
+++ b/backend/internal/engine/page_renderer.go
@@ -301,7 +301,7 @@ func (r *PageRenderer) RenderPost(buildDir string, post domain.Post, baseData *t
 	html, err := r.renderer.Render(templateName, &postData)
 	if err != nil {
 		r.logger.Error(fmt.Sprintf("文章模板渲染失败: %v，使用简单模板", err))
-		return r.renderSimplePost(postDir, &postData)
+		return r.renderSimplePost(postDir, &postData, isSpecialPage)
 	}
 
 	// 后处理：SEO 注入 + CDN URL 重写
@@ -658,20 +658,86 @@ func (r *PageRenderer) Render404(buildDir string, data *template.TemplateData) e
 	return r.manifest.WriteFile(filepath.Join(buildDir, "404.html"), buf.Bytes(), 0644)
 }
 
-// renderSimpleIndex 渲染简单首页（备用）
+// fallbackBannerHTML 所有降级视图顶部展示的醒目提示，帮助用户意识到主题模板
+// 渲染失败，而非误以为是终态样式。
+const fallbackBannerHTML = `<div class="fallback-banner" style="background:#fff3cd; color:#856404; border:1px solid #ffeeba; padding:12px 16px; margin:0 0 24px; border-radius:4px; font-size:14px;">` +
+	`⚠️ <strong>降级视图</strong>：主题模板渲染失败，当前为临时兜底页面，请检查主题配置或模板语法。` +
+	`</div>`
+
+// renderSimpleIndex 渲染简单首页（备用）。
+// 与主流程一致地按 PostPageSize 分页输出，保证访问 /page/N/ 仍可落地，
+// 避免原实现只写 page 1 导致 manifest 把旧的 page/N/ 目录当孤儿清掉后 404。
 func (r *PageRenderer) renderSimpleIndex(buildDir string, data *template.TemplateData) error {
+	listPosts := getVisiblePosts(data.Posts)
+	ps := pageSize(data.ThemeConfig.PostPageSize, 10)
+	total := len(listPosts)
+	totalPages := (total + ps - 1) / ps
+	if totalPages < 1 {
+		totalPages = 1
+	}
+
+	for page := 1; page <= totalPages; page++ {
+		start := (page - 1) * ps
+		end := start + ps
+		if end > total {
+			end = total
+		}
+		var pagePosts []template.PostView
+		if total > 0 {
+			pagePosts = listPosts[start:end]
+		}
+
+		var outDir string
+		if page == 1 {
+			outDir = buildDir
+		} else {
+			outDir = filepath.Join(buildDir, "page", fmt.Sprintf("%d", page))
+			if err := os.MkdirAll(outDir, 0755); err != nil {
+				return err
+			}
+		}
+
+		html := r.buildSimpleIndexHTML(data, pagePosts, page, totalPages)
+		if err := r.manifest.WriteFile(filepath.Join(outDir, FileIndexHTML), []byte(html), 0644); err != nil {
+			return err
+		}
+	}
+
+	r.logger.Info(fmt.Sprintf("🛟 首页降级视图已生成（共 %d 页）", totalPages))
+	return nil
+}
+
+// buildSimpleIndexHTML 构建单个简单首页的完整 HTML，含分页导航。
+// baseURL 固定为 "/"（与 RenderIndex 一致）。
+func (r *PageRenderer) buildSimpleIndexHTML(data *template.TemplateData, posts []template.PostView, page, totalPages int) string {
 	buf := bufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer bufferPool.Put(buf)
 
 	var postListHTML strings.Builder
-	for _, p := range data.Posts {
+	for _, p := range posts {
 		postListHTML.WriteString(fmt.Sprintf(`
 			<article class="post">
 				<h2 class="post-title"><a href="%s">%s</a></h2>
 				<div class="post-meta">%s</div>
 			</article>
 		`, p.Link, p.Title, p.DateFormat))
+	}
+
+	pagination := buildPagination(page, totalPages, len(data.Posts), "/")
+	var paginationHTML string
+	if totalPages > 1 {
+		var sb strings.Builder
+		sb.WriteString(`<nav class="pagination" style="text-align:center; margin:40px 0; padding:20px 0; border-top:1px solid #eee;">`)
+		if pagination.HasPrev {
+			sb.WriteString(fmt.Sprintf(`<a href="%s" style="margin:0 12px; color:#0066cc; text-decoration:none;">← 上一页</a>`, pagination.PrevURL))
+		}
+		sb.WriteString(fmt.Sprintf(`<span style="color:#999;">%d / %d</span>`, page, totalPages))
+		if pagination.HasNext {
+			sb.WriteString(fmt.Sprintf(`<a href="%s" style="margin:0 12px; color:#0066cc; text-decoration:none;">下一页 →</a>`, pagination.NextURL))
+		}
+		sb.WriteString(`</nav>`)
+		paginationHTML = sb.String()
 	}
 
 	fmt.Fprintf(buf, `<!DOCTYPE html>
@@ -693,24 +759,36 @@ func (r *PageRenderer) renderSimpleIndex(buildDir string, data *template.Templat
 	</style>
 </head>
 <body>
+	%s
 	<header class="site-header">
 		<h1 class="site-title">%s</h1>
 		<p class="site-description">%s</p>
 	</header>
 	<main class="site-main">%s</main>
+	%s
 	<footer style="text-align: center; padding: 40px 0; color: #999;">%s</footer>
 </body>
-</html>`, data.ThemeConfig.SiteName, data.ThemeConfig.SiteName, data.ThemeConfig.SiteDescription,
-		postListHTML.String(), data.ThemeConfig.FooterInfo)
+</html>`, data.ThemeConfig.SiteName, fallbackBannerHTML, data.ThemeConfig.SiteName, data.ThemeConfig.SiteDescription,
+		postListHTML.String(), paginationHTML, data.ThemeConfig.FooterInfo)
 
-	return r.manifest.WriteFile(filepath.Join(buildDir, FileIndexHTML), buf.Bytes(), 0644)
+	return buf.String()
 }
 
-// renderSimplePost 渲染简单文章页（备用）
-func (r *PageRenderer) renderSimplePost(postDir string, data *template.TemplateData) error {
+// renderSimplePost 渲染简单文章页（备用）。
+// isSpecialPage = true 时去掉"返回首页"链接与日期元信息，更贴近静态页（about / privacy）的语义。
+func (r *PageRenderer) renderSimplePost(postDir string, data *template.TemplateData, isSpecialPage bool) error {
 	buf := bufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer bufferPool.Put(buf)
+
+	metaLine := ""
+	backLink := `<a href="/" class="back-link">← 返回首页</a>`
+	if isSpecialPage {
+		// about / privacy 之类的页面：没有发布日期的语义，也通常通过导航访问，不需要"返回首页"
+		backLink = ""
+	} else {
+		metaLine = fmt.Sprintf(`<div class="post-meta">%s</div>`, data.Post.DateFormat)
+	}
 
 	fmt.Fprintf(buf, `<!DOCTYPE html>
 <html lang="zh-CN">
@@ -730,22 +808,19 @@ func (r *PageRenderer) renderSimplePost(postDir string, data *template.TemplateD
 	</style>
 </head>
 <body>
+	%s
 	<article class="post">
 		<header class="post-header">
 			<h1 class="post-title">%s</h1>
-			<div class="post-meta">%s</div>
+			%s
 		</header>
 		<div class="post-content">%s</div>
 	</article>
-	<a href="/" class="back-link">← 返回首页</a>
+	%s
 	<footer style="text-align: center; padding: 40px 0; color: #999;">%s</footer>
 </body>
-</html>`, data.SiteTitle, data.Post.Title, data.Post.DateFormat, data.Post.Content, data.ThemeConfig.FooterInfo)
+</html>`, data.SiteTitle, fallbackBannerHTML, data.Post.Title, metaLine, data.Post.Content, backLink, data.ThemeConfig.FooterInfo)
 
 	indexPath := filepath.Join(postDir, FileIndexHTML)
-	if err := r.manifest.WriteFile(indexPath, buf.Bytes(), 0644); err != nil {
-		return err
-	}
-
-	return nil
+	return r.manifest.WriteFile(indexPath, buf.Bytes(), 0644)
 }

--- a/backend/internal/engine/page_renderer_test.go
+++ b/backend/internal/engine/page_renderer_test.go
@@ -1,0 +1,241 @@
+package engine
+
+import (
+	"fmt"
+	"gridea-pro/backend/internal/domain"
+	"gridea-pro/backend/internal/template"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestPageRenderer 构造一个仅用于兜底测试的 PageRenderer：
+// 不依赖 renderer 与 dataBuilder，仅需 manifest 能写文件。
+func newTestPageRenderer(t *testing.T, buildDir string) *PageRenderer {
+	t.Helper()
+	return &PageRenderer{
+		logger:   slog.Default(),
+		manifest: NewRenderManifest(buildDir),
+	}
+}
+
+func mkVisiblePost(title string) template.PostView {
+	return template.PostView{
+		Title:      title,
+		FileName:   strings.ReplaceAll(strings.ToLower(title), " ", "-"),
+		Link:       "/post/" + strings.ReplaceAll(strings.ToLower(title), " ", "-") + "/",
+		DateFormat: "2026-04-22",
+		Published:  true,
+	}
+}
+
+func TestRenderSimpleIndex_Pagination(t *testing.T) {
+	buildDir := t.TempDir()
+	r := newTestPageRenderer(t, buildDir)
+
+	// 25 篇文章，每页 10 篇 → 3 页
+	posts := make([]template.PostView, 25)
+	for i := range posts {
+		posts[i] = mkVisiblePost(fmt.Sprintf("Post %d", i+1))
+	}
+
+	data := &template.TemplateData{
+		ThemeConfig: template.ThemeConfigView{
+			SiteName:         "Test",
+			PostPageSize:     10,
+			ThemeName:        "test",
+		},
+		Posts: posts,
+	}
+
+	if err := r.renderSimpleIndex(buildDir, data); err != nil {
+		t.Fatalf("renderSimpleIndex failed: %v", err)
+	}
+
+	// 第 1 页落在 buildDir/index.html
+	page1 := filepath.Join(buildDir, "index.html")
+	if _, err := os.Stat(page1); err != nil {
+		t.Fatalf("page 1 missing: %v", err)
+	}
+	// 第 2 页落在 buildDir/page/2/index.html
+	page2 := filepath.Join(buildDir, "page", "2", "index.html")
+	if _, err := os.Stat(page2); err != nil {
+		t.Fatalf("page 2 missing: %v", err)
+	}
+	// 第 3 页落在 buildDir/page/3/index.html
+	page3 := filepath.Join(buildDir, "page", "3", "index.html")
+	if _, err := os.Stat(page3); err != nil {
+		t.Fatalf("page 3 missing: %v", err)
+	}
+
+	// 降级 banner 应出现在每一页
+	for _, p := range []string{page1, page2, page3} {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "降级视图") {
+			t.Errorf("%s missing fallback banner", filepath.Base(filepath.Dir(p)))
+		}
+	}
+
+	// 第 1 页只含前 10 篇标题（<a>Post N</a> 形式）
+	p1Content, _ := os.ReadFile(page1)
+	if !strings.Contains(string(p1Content), ">Post 1<") {
+		t.Error("page 1 should contain Post 1")
+	}
+	if !strings.Contains(string(p1Content), ">Post 10<") {
+		t.Error("page 1 should contain Post 10")
+	}
+	if strings.Contains(string(p1Content), ">Post 11<") {
+		t.Error("page 1 should NOT contain Post 11")
+	}
+	// 分页导航
+	if !strings.Contains(string(p1Content), "/page/2/") {
+		t.Error("page 1 should link to /page/2/")
+	}
+
+	// 第 3 页含最后 5 篇
+	p3Content, _ := os.ReadFile(page3)
+	if !strings.Contains(string(p3Content), ">Post 21<") {
+		t.Error("page 3 should contain Post 21")
+	}
+	if !strings.Contains(string(p3Content), ">Post 25<") {
+		t.Error("page 3 should contain Post 25")
+	}
+	// 第 3 页无"下一页"
+	if strings.Contains(string(p3Content), "/page/4/") {
+		t.Error("page 3 should NOT link to /page/4/")
+	}
+}
+
+func TestRenderSimpleIndex_HidesUnpublished(t *testing.T) {
+	buildDir := t.TempDir()
+	r := newTestPageRenderer(t, buildDir)
+
+	posts := []template.PostView{
+		{Title: "Visible", FileName: "visible", Link: "/post/visible/", Published: true},
+		{Title: "Draft", FileName: "draft", Link: "/post/draft/", Published: false},
+		{Title: "Hidden", FileName: "hidden", Link: "/post/hidden/", Published: true, HideInList: true},
+	}
+	data := &template.TemplateData{
+		ThemeConfig: template.ThemeConfigView{SiteName: "Test", PostPageSize: 10},
+		Posts:       posts,
+	}
+
+	if err := r.renderSimpleIndex(buildDir, data); err != nil {
+		t.Fatalf("renderSimpleIndex failed: %v", err)
+	}
+
+	b, _ := os.ReadFile(filepath.Join(buildDir, "index.html"))
+	content := string(b)
+	if !strings.Contains(content, "Visible") {
+		t.Error("visible post missing")
+	}
+	if strings.Contains(content, "Draft") {
+		t.Error("draft post should not appear")
+	}
+	if strings.Contains(content, "Hidden") {
+		t.Error("hide-in-list post should not appear on home page")
+	}
+}
+
+func TestRenderSimpleIndex_EmptyPostsStillWritesIndex(t *testing.T) {
+	buildDir := t.TempDir()
+	r := newTestPageRenderer(t, buildDir)
+
+	data := &template.TemplateData{
+		ThemeConfig: template.ThemeConfigView{SiteName: "Test", PostPageSize: 10},
+		Posts:       nil,
+	}
+	if err := r.renderSimpleIndex(buildDir, data); err != nil {
+		t.Fatalf("renderSimpleIndex failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(buildDir, "index.html")); err != nil {
+		t.Fatalf("even with no posts, index.html must exist: %v", err)
+	}
+}
+
+func TestRenderSimplePost_SpecialPage(t *testing.T) {
+	buildDir := t.TempDir()
+	r := newTestPageRenderer(t, buildDir)
+
+	data := &template.TemplateData{
+		ThemeConfig: template.ThemeConfigView{SiteName: "Test"},
+		SiteTitle:   "About | Test",
+		Post: template.PostView{
+			Title:      "About Me",
+			Content:    "<p>Hello</p>",
+			DateFormat: "2026-04-22",
+		},
+	}
+
+	postDir := filepath.Join(buildDir, "about")
+	_ = os.MkdirAll(postDir, 0o755)
+
+	if err := r.renderSimplePost(postDir, data, true); err != nil {
+		t.Fatalf("renderSimplePost failed: %v", err)
+	}
+
+	b, _ := os.ReadFile(filepath.Join(postDir, "index.html"))
+	content := string(b)
+
+	// 特殊页：不显示"返回首页"链接与日期元数据
+	if strings.Contains(content, "返回首页") {
+		t.Error("special page should not show back-to-home link")
+	}
+	if strings.Contains(content, "2026-04-22") {
+		t.Error("special page should not show post-meta date")
+	}
+	if !strings.Contains(content, "About Me") {
+		t.Error("title missing")
+	}
+	if !strings.Contains(content, "<p>Hello</p>") {
+		t.Error("content missing")
+	}
+	// 降级 banner 必须保留
+	if !strings.Contains(content, "降级视图") {
+		t.Error("missing fallback banner")
+	}
+}
+
+func TestRenderSimplePost_RegularPost(t *testing.T) {
+	buildDir := t.TempDir()
+	r := newTestPageRenderer(t, buildDir)
+
+	data := &template.TemplateData{
+		ThemeConfig: template.ThemeConfigView{SiteName: "Test"},
+		SiteTitle:   "Post | Test",
+		Post: template.PostView{
+			Title:      "My Post",
+			Content:    "<p>Body</p>",
+			DateFormat: "2026-04-22",
+		},
+	}
+
+	postDir := filepath.Join(buildDir, "post", "my-post")
+	_ = os.MkdirAll(postDir, 0o755)
+
+	if err := r.renderSimplePost(postDir, data, false); err != nil {
+		t.Fatalf("renderSimplePost failed: %v", err)
+	}
+
+	b, _ := os.ReadFile(filepath.Join(postDir, "index.html"))
+	content := string(b)
+
+	if !strings.Contains(content, "返回首页") {
+		t.Error("regular post should show back-to-home link")
+	}
+	if !strings.Contains(content, "2026-04-22") {
+		t.Error("regular post should show post-meta date")
+	}
+	if !strings.Contains(content, "降级视图") {
+		t.Error("missing fallback banner")
+	}
+}
+
+// 让 linter 不抱怨未使用的 domain import；保留以防后续扩展
+var _ = domain.Post{}


### PR DESCRIPTION
## Summary

修复 #62：

- \`RenderIndex\` 降级到 \`renderSimpleIndex\` 时只写第 1 页，\`page/2\` 等分页目录缺失。叠加 manifest 增量清理后，旧 \`page/N/\` 目录被当孤儿删除，用户访问 \`/page/2/\` 直接 404
- \`RenderPost\` 的降级对专属模板（\`about.html\` / \`privacy.html\` 等）与普通文章一视同仁，展示"带返回首页按钮 + 发布日期"的文章样式，与页面语义不符
- 降级视图与终态样式视觉接近，用户可能意识不到主题模板报错

## 修复方案

- \`renderSimpleIndex\` 按 \`PostPageSize\` 循环输出每一页，构建 \`buildPagination\` 的上下一页链接；数据源改为 \`getVisiblePosts\`（与主流程一致，顺带修掉原先把草稿 / hideInList 文章渲到降级首页的隐性 bug）
- \`renderSimplePost\` 新增 \`isSpecialPage bool\` 参数：special page 省去"返回首页"和日期元信息，更贴静态页语义。\`RenderPost\` 调用点传递本地已有的 \`isSpecialPage\` 变量
- 两个降级页顶部统一插入 \`fallbackBannerHTML\`（黄色警告条），明示"主题模板渲染失败，当前为临时兜底页面"

## 未选的替代方案

issue 里提到的"方案 B：直接把错误冒泡给前端、不降级"是更强的反馈方式，但降级能保持站点可用，预览场景下也有价值；加醒目 banner 相当于折中版"方案 A + 方案 C"。

## Test plan

- [x] \`go test ./backend/internal/engine/...\` — 5 个新增 case 全绿：25 篇文章 3 页分页、空站点仍写首页、草稿/hideInList 过滤、special page vs regular post 降级差异、banner 出现在每一页
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 人工回归：故意把主题 \`index.html\` 写成语法错误，构建后查看生成目录应包含完整的 page/N/index.html 以及 banner 提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)