### PR TITLE
refactor(engine): asyncTasks 改用 WaitGroup + sem channel，去掉双错误收集 (#65)

### DIFF
--- a/backend/internal/engine/engine.go
+++ b/backend/internal/engine/engine.go
@@ -328,7 +328,7 @@ func (s *Engine) renderAllImpl(ctx context.Context) error {
 		errs = errors.Join(errs, err)
 	}
 
-	// 完全独立、无依赖的页面与元数据生成，运用 errgroup 并发执行
+	// 完全独立、无依赖的页面与元数据生成
 	asyncTasks := []renderTask{
 		{"友链页", func() error { return s.pageRenderer.RenderFriends(ctx, buildDir, templateData) }},
 		{"闪念页", func() error { return s.pageRenderer.RenderMemos(ctx, buildDir, templateData) }},
@@ -366,36 +366,38 @@ func (s *Engine) renderAllImpl(ctx context.Context) error {
 		}},
 	}
 
-	asyncGroup, asyncCtx := errgroup.WithContext(ctx)
-	asyncGroup.SetLimit(10)
-
-	var asyncErrs error
-	var errsMu sync.Mutex
+	// 并发跑独立任务：刻意不使用 errgroup，避免单个任务失败通过 errgroup.WithContext
+	// 取消其他任务（asyncTasks 里任一任务失败不影响其余的渲染产物）。
+	// 限流 10 并发，错误各自聚合后一次性加入 errs。
+	const asyncConcurrency = 10
+	var (
+		asyncWG sync.WaitGroup
+		asyncMu sync.Mutex
+		sem     = make(chan struct{}, asyncConcurrency)
+	)
 
 	for _, task := range asyncTasks {
 		t := task
-		asyncGroup.Go(func() error {
+		asyncWG.Go(func() {
 			select {
-			case <-asyncCtx.Done():
-				return asyncCtx.Err()
-			default:
+			case <-ctx.Done():
+				asyncMu.Lock()
+				errs = errors.Join(errs, ctx.Err())
+				asyncMu.Unlock()
+				return
+			case sem <- struct{}{}:
 			}
+			defer func() { <-sem }()
+
 			if err := t.fn(); err != nil {
 				s.logger.Error(fmt.Sprintf("警告：%s并发生成失败: %v", t.name, err))
-				errsMu.Lock()
-				asyncErrs = errors.Join(asyncErrs, fmt.Errorf("%s失败: %w", t.name, err))
-				errsMu.Unlock()
+				asyncMu.Lock()
+				errs = errors.Join(errs, fmt.Errorf("%s失败: %w", t.name, err))
+				asyncMu.Unlock()
 			}
-			return nil
 		})
 	}
-
-	if err := asyncGroup.Wait(); err != nil {
-		errs = errors.Join(errs, err)
-	}
-	if asyncErrs != nil {
-		errs = errors.Join(errs, asyncErrs)
-	}
+	asyncWG.Wait()
 
 	// CSS 合并压缩（后处理）
 	themePath := filepath.Join(s.appDir, DirThemes, themeConfig.ThemeName)


### PR DESCRIPTION
## Summary

\`Engine.renderAllImpl\` 里 \`asyncTasks\` 原本用 \`errgroup\` 并发执行独立任务，但每个 goroutine 刻意始终返回 \`nil\`（否则 errgroup 会取消其他任务），错误收集走 \`errgroup.Wait()\` 和自定义 \`asyncErrs + errsMu\` 两套机制。读者容易疑惑"为什么要用 errgroup 却不接它的错误"。

## 重构

- 改用 \`sync.WaitGroup.Go\`（Go 1.25+）+ 信号量 channel 限流 10
- 错误直接聚合到外层 \`errs\`，删除独立的 \`asyncErrs\` / \`errsMu\`
- 语义更直白：**并发跑 + 限流 + 聚合错误**，不牵扯 ctx 取消传播

## 顺带修了一个边界

原版在 \`errgroup.SetLimit\` 的槽位上阻塞等待时不响应 \`ctx\` 取消；新版的 \`select\` 在 \`sem <- struct{}{}\` 与 \`ctx.Done()\` 之间，取消更及时。

## 单任务失败不影响其他任务的语义不变。

## 保留 errgroup 的地方

文章详情页并发渲染（\`g, _ := errgroup.WithContext(ctx)\` 那块）没动 —— 那里要的是"任一 post 渲染失败就返回首个错误"，errgroup 的默认语义正合适。

## Test plan

- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [x] \`go test ./backend/...\` 绿
- [ ] 人工回归：故意让 RSS / sitemap 生成失败（比如磁盘权限），观察其他 asset（404 / manifest.json / sw.js）仍能生成，且错误被聚合报告

🤖 Generated with [Claude Code](https://claude.com/claude-code)