### PR TITLE
refactor(engine): Tag 渲染迁移到 ID-first，对齐 Category 模式 (#58)

### DIFF
--- a/backend/internal/engine/data_builder.go
+++ b/backend/internal/engine/data_builder.go
@@ -35,6 +35,7 @@ type TemplateDataBuilder struct {
 	logger             *slog.Logger
 
 	// Build() 阶段缓存的查找映射，供 ConvertPost() 复用
+	cachedTagByID        map[string]domain.Tag
 	cachedTagByName      map[string]domain.Tag
 	cachedCategoryByID   map[string]domain.Category
 	cachedCategoryByName map[string]domain.Category
@@ -102,18 +103,32 @@ func (b *TemplateDataBuilder) Build(ctx context.Context, posts []domain.Post, co
 	}
 
 	// 3. 预加载标签映射，供 convertPost 使用
+	//    - tagByID: id → Tag（主键，与 Category 对齐；Post.TagIDs 优先走此路径）
+	//    - tagByName: name → Tag（兜底，用于老文章无 TagIDs 时按名称反查 slug）
+	tagByID := make(map[string]domain.Tag)
 	tagByName := make(map[string]domain.Tag)
 	if b.tagRepo != nil {
 		if repoTags, err := b.tagRepo.List(ctx); err == nil {
 			for _, rt := range repoTags {
+				if rt.ID != "" {
+					tagByID[rt.ID] = rt
+				}
+				// 重名标签（手工编辑 JSON 造成）保留先添加的，避免隐式覆盖导致
+				// 按名查到的 slug 不稳定；数据层唯一性约束（#66）已阻止新建重名
 				if rt.Name != "" {
-					tagByName[rt.Name] = rt
+					if _, exists := tagByName[rt.Name]; !exists {
+						tagByName[rt.Name] = rt
+					} else {
+						b.logger.Warn("检测到重名标签，按名查找将保留先添加的",
+							"name", rt.Name, "duplicate_id", rt.ID)
+					}
 				}
 			}
 		}
 	}
 
 	// 缓存查找映射，供 ConvertPost() 在渲染单篇文章时复用
+	b.cachedTagByID = tagByID
 	b.cachedTagByName = tagByName
 	b.cachedCategoryByID = categoryByID
 	b.cachedCategoryByName = categoryByName
@@ -130,7 +145,7 @@ func (b *TemplateDataBuilder) Build(ctx context.Context, posts []domain.Post, co
 			sem <- struct{}{}        // Acquire
 			defer func() { <-sem }() // Release
 
-			postViews[idx] = b.convertPost(p, config, categoryByID, categoryByName, tagByName)
+			postViews[idx] = b.convertPost(p, config, categoryByID, categoryByName, tagByID, tagByName)
 		}(i, post)
 	}
 	wg.Wait()
@@ -402,11 +417,11 @@ func (b *TemplateDataBuilder) ConvertPost(post domain.Post, config domain.ThemeC
 	if categoryByID == nil {
 		categoryByID = b.cachedCategoryByID
 	}
-	return b.convertPost(post, config, categoryByID, b.cachedCategoryByName, b.cachedTagByName)
+	return b.convertPost(post, config, categoryByID, b.cachedCategoryByName, b.cachedTagByID, b.cachedTagByName)
 }
 
 // convertPost 将 domain.Post 转换为 template.PostView
-func (b *TemplateDataBuilder) convertPost(post domain.Post, config domain.ThemeConfig, categoryByID map[string]domain.Category, categoryByName map[string]domain.Category, tagByName map[string]domain.Tag) template.PostView {
+func (b *TemplateDataBuilder) convertPost(post domain.Post, config domain.ThemeConfig, categoryByID map[string]domain.Category, categoryByName map[string]domain.Category, tagByID map[string]domain.Tag, tagByName map[string]domain.Tag) template.PostView {
 	postPath := config.PostPath
 	if postPath == "" {
 		postPath = DefaultPostPath
@@ -415,23 +430,40 @@ func (b *TemplateDataBuilder) convertPost(post domain.Post, config domain.ThemeC
 	// 生成链接
 	link := "/" + postPath + "/" + post.FileName + "/"
 
-	// 转换标签
+	// 转换标签：优先走 TagIDs（与 Category 对齐），未命中 / 老文章回退到 Name 反查。
+	// 这样同名但不同 ID 的标签也能被正确解析到各自的 Slug，不受 map 覆盖影响。
 	var tags []template.TagView
 	var tagNames []string
-	for _, tag := range post.Tags {
-		tagSlug := tag
-		if tagByName != nil {
-			if t, ok := tagByName[tag]; ok {
-				tagSlug = t.Slug
+	if len(post.TagIDs) > 0 && tagByID != nil {
+		for _, tagID := range post.TagIDs {
+			if t, ok := tagByID[tagID]; ok {
+				tags = append(tags, template.TagView{
+					Name: t.Name,
+					Slug: t.Slug,
+					Link: "/" + config.TagPath + "/" + t.Slug + "/",
+				})
+				tagNames = append(tagNames, t.Name)
 			}
+			// ID 未命中（标签被删除后仍被 post 引用）：跳过，不渲染死链；
+			// 处理方式与 Category ID 未命中的容错保持一致的思路（此处直接丢弃，
+			// 不输出 NanoID 作为 Name，避免前台出现形如 "V1StGXR8" 的假标签）
 		}
-		tagView := template.TagView{
-			Name: tag,
-			Slug: tagSlug,
-			Link: "/" + config.TagPath + "/" + tagSlug + "/",
+	} else {
+		// 向后兼容：老文章无 TagIDs，按 Name 反查
+		for _, tag := range post.Tags {
+			tagSlug := tag
+			if tagByName != nil {
+				if t, ok := tagByName[tag]; ok {
+					tagSlug = t.Slug
+				}
+			}
+			tags = append(tags, template.TagView{
+				Name: tag,
+				Slug: tagSlug,
+				Link: "/" + config.TagPath + "/" + tagSlug + "/",
+			})
+			tagNames = append(tagNames, tag)
 		}
-		tags = append(tags, tagView)
-		tagNames = append(tagNames, tag)
 	}
 
 	// 转换分类：严格基于 CategoryIDs 查找

--- a/backend/internal/engine/data_builder_test.go
+++ b/backend/internal/engine/data_builder_test.go
@@ -1,0 +1,150 @@
+package engine
+
+import (
+	"log/slog"
+	"testing"
+
+	"gridea-pro/backend/internal/domain"
+)
+
+func newTestBuilder() *TemplateDataBuilder {
+	return &TemplateDataBuilder{
+		logger: slog.Default(),
+	}
+}
+
+func TestConvertPost_TagIDsResolveViaTagByID(t *testing.T) {
+	b := newTestBuilder()
+
+	// 两个同名但不同 ID / Slug 的标签（数据层唯一性约束下不会发生，
+	// 但 ID-first 逻辑必须能正确处理，不受 Name 重复影响）
+	tagByID := map[string]domain.Tag{
+		"id-a": {ID: "id-a", Name: "Go", Slug: "go-lang"},
+		"id-b": {ID: "id-b", Name: "Rust", Slug: "rust"},
+	}
+	tagByName := map[string]domain.Tag{
+		"Go":   tagByID["id-a"],
+		"Rust": tagByID["id-b"],
+	}
+
+	post := domain.Post{
+		FileName: "hello",
+		Tags:     []string{"Go", "Rust"},
+		TagIDs:   []string{"id-a", "id-b"},
+	}
+	config := domain.ThemeConfig{TagPath: "tag"}
+
+	view := b.convertPost(post, config, nil, nil, tagByID, tagByName)
+
+	if len(view.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(view.Tags))
+	}
+	if view.Tags[0].Slug != "go-lang" {
+		t.Errorf("expected Slug go-lang from tagByID, got %q", view.Tags[0].Slug)
+	}
+	if view.Tags[0].Link != "/tag/go-lang/" {
+		t.Errorf("expected link /tag/go-lang/, got %q", view.Tags[0].Link)
+	}
+	if view.Tags[1].Slug != "rust" {
+		t.Errorf("expected Slug rust, got %q", view.Tags[1].Slug)
+	}
+}
+
+func TestConvertPost_LegacyNoTagIDsFallsBackToName(t *testing.T) {
+	b := newTestBuilder()
+
+	tagByID := map[string]domain.Tag{
+		"id-a": {ID: "id-a", Name: "Go", Slug: "go"},
+	}
+	tagByName := map[string]domain.Tag{
+		"Go": tagByID["id-a"],
+	}
+
+	// 老文章：只有 Tags（Name），没有 TagIDs
+	post := domain.Post{
+		FileName: "old-post",
+		Tags:     []string{"Go"},
+		TagIDs:   nil,
+	}
+	config := domain.ThemeConfig{TagPath: "tag"}
+
+	view := b.convertPost(post, config, nil, nil, tagByID, tagByName)
+
+	if len(view.Tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(view.Tags))
+	}
+	if view.Tags[0].Name != "Go" {
+		t.Errorf("expected Name Go, got %q", view.Tags[0].Name)
+	}
+	if view.Tags[0].Slug != "go" {
+		t.Errorf("expected Slug go from tagByName, got %q", view.Tags[0].Slug)
+	}
+}
+
+func TestConvertPost_TagIDMissingIsSkipped(t *testing.T) {
+	b := newTestBuilder()
+
+	tagByID := map[string]domain.Tag{
+		"id-a": {ID: "id-a", Name: "Go", Slug: "go"},
+		// id-b 被删除后仍被 post 引用
+	}
+	tagByName := map[string]domain.Tag{
+		"Go": tagByID["id-a"],
+	}
+
+	post := domain.Post{
+		FileName: "hello",
+		Tags:     []string{"Go", "DeletedTag"},
+		TagIDs:   []string{"id-a", "id-b"},
+	}
+	config := domain.ThemeConfig{TagPath: "tag"}
+
+	view := b.convertPost(post, config, nil, nil, tagByID, tagByName)
+
+	// id-b 命中失败 → 跳过；不应输出 NanoID 作为假标签
+	if len(view.Tags) != 1 {
+		t.Fatalf("expected 1 tag (missing id skipped), got %d: %+v", len(view.Tags), view.Tags)
+	}
+	if view.Tags[0].Slug != "go" {
+		t.Errorf("expected Slug go, got %q", view.Tags[0].Slug)
+	}
+	if view.TagsString != "Go" {
+		t.Errorf("expected TagsString=Go, got %q", view.TagsString)
+	}
+}
+
+func TestConvertPost_DuplicateNameDifferentSlugResolvedByID(t *testing.T) {
+	b := newTestBuilder()
+
+	// 模拟数据层"脏数据"场景：同名标签指向不同 Slug
+	// 按 Name 反查会覆盖，按 ID 反查各自独立
+	tagByID := map[string]domain.Tag{
+		"id-a": {ID: "id-a", Name: "Lang", Slug: "lang-a"},
+		"id-b": {ID: "id-b", Name: "Lang", Slug: "lang-b"}, // 与 id-a 同名
+	}
+	// tagByName 只会保留一个（先添加的）
+	tagByName := map[string]domain.Tag{
+		"Lang": tagByID["id-a"],
+	}
+
+	post := domain.Post{
+		FileName: "x",
+		Tags:     []string{"Lang", "Lang"},
+		TagIDs:   []string{"id-a", "id-b"},
+	}
+	config := domain.ThemeConfig{TagPath: "tag"}
+
+	view := b.convertPost(post, config, nil, nil, tagByID, tagByName)
+
+	// 重名在数据层约束下虽不应发生，但 ID-first 路径要能正确分流
+	if len(view.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(view.Tags))
+	}
+	if view.Tags[0].Slug == view.Tags[1].Slug {
+		t.Errorf("ID-first 路径应产生不同的 Slug，得到相同: %+v", view.Tags)
+	}
+	slugs := map[string]bool{view.Tags[0].Slug: true, view.Tags[1].Slug: true}
+	if !slugs["lang-a"] || !slugs["lang-b"] {
+		t.Errorf("expected slugs lang-a and lang-b, got %v", slugs)
+	}
+}

--- a/backend/internal/engine/page_renderer.go
+++ b/backend/internal/engine/page_renderer.go
@@ -413,10 +413,12 @@ func (r *PageRenderer) RenderTagPages(ctx context.Context, buildDir string, data
 			default:
 			}
 
+			// 按 Slug 匹配（与 RenderCategoryPages 对齐）。Slug 唯一性由数据层约束（#66）
+			// 保证，重名 Name 也不会导致错误的文章分组。
 			var tagPosts []template.PostView
 			for _, post := range data.Posts {
 				for _, pt := range post.Tags {
-					if pt.Name == tg.Name {
+					if pt.Slug == tg.Slug {
 						tagPosts = append(tagPosts, post)
 						break
 					}


### PR DESCRIPTION
## Summary

\`domain.Post\` 早就双写了 \`Tags\`（Name 数组）和 \`TagIDs\`，但渲染层仍按 Name 反查：

- \`convertPost\` 循环 \`post.Tags\` 用 \`tagByName\` 反查 Slug
- \`RenderTagPages\` 用 \`pt.Name == tg.Name\` 分组

\`TagIDs\` 成半死字段；遇到手工编辑 JSON 引入的重名 Tag 时，\`tagByName\` 会覆盖，不同 Slug 的同名 tag 被错误合并到同一目录。

## 修复方案

对齐 Category 的 ID-first 模式：

- \`TemplateDataBuilder\` 新增 \`cachedTagByID\` + \`tagByID\` 映射；重名 tag 告警保留先添加（与 category 已有的处理一致）
- \`convertPost\` 补 \`tagByID\` 形参。\`post.TagIDs\` 非空时优先走 ID 路径，命中失败的陈旧引用直接丢弃（不渲染形如 NanoID 的假标签）；老文章无 \`TagIDs\` 仍走原 Name 兜底路径，行为不变
- \`page_renderer.RenderTagPages\` 匹配改为 \`pt.Slug == tg.Slug\`（与 \`RenderCategoryPages\` 一致）。\`TagView\` 不暴露 ID 给模板，与 \`CategoryView\` 保持对称；Slug 唯一性由 #66 的数据层约束保证

## 与相邻 PR 的关系

- 和 #72 (#59 兜底 Slug URL 处理) 有轻微交叠：legacy Name 兜底路径里 \`tagSlug = tag\` 的旧 bug 在本 PR 没改（为了 diff 最小化），#72 合并后会覆盖到
- 和 #76 (#66 唯一性约束) 是协同关系：唯一性约束保证了"ID 迁移后数据仍稳定"的前提

## Test plan

- [x] \`go test ./backend/internal/engine/...\` — 4 个新增 case 全绿：ID 优先解析 / 老文章 Name 兜底 / ID 未命中跳过 / 重名不同 Slug 通过 ID 正确分流
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 人工回归：重命名一个标签，检查该标签下所有文章的链接都指向新 Slug；制造一个不带 TagIDs 的老文章（直接编辑 JSON），应仍能正确渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)