### PR TITLE
fix(update): StartDownload 清理旧 readyPath，避免误装旧包 (#56)

### DIFF
--- a/backend/internal/facade/update_facade.go
+++ b/backend/internal/facade/update_facade.go
@@ -131,6 +131,14 @@ func (f *UpdateFacade) StartDownload() error {
 		f.mu.Unlock()
 		return errors.New("已经有下载任务在运行")
 	}
+	// 清理上一轮可能遗留的 ready 状态：避免"上一次下载成功但用户没点立即更新
+	// 之后这一次下载失败"的组合下，ApplyUpdate 误用上一次的旧包。
+	// 同时尝试删除磁盘上的旧临时文件（容忍失败，文件可能被系统清理）。
+	if f.readyPath != "" {
+		_ = os.Remove(f.readyPath)
+	}
+	f.readyPath = ""
+	f.readyAssetName = ""
 	ctx, cancel := context.WithCancel(context.Background())
 	f.downloadCancel = cancel
 	f.mu.Unlock()

--- a/backend/internal/facade/update_facade_test.go
+++ b/backend/internal/facade/update_facade_test.go
@@ -1,0 +1,109 @@
+package facade
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newTestFacadeWith404 返回一个 UpdateFacade，其 releasesURL 指向本地 404 服务，
+// 用于模拟"新下载失败"的场景。clientTimeout 可调以避免测试过慢。
+func newTestFacadeWith404(t *testing.T) (*UpdateFacade, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no release", http.StatusNotFound)
+	}))
+	f := &UpdateFacade{
+		releasesURL: srv.URL,
+		httpClient:  &http.Client{Timeout: 2 * time.Second},
+	}
+	return f, func() { srv.Close() }
+}
+
+// 关键修复：连续两次下载（第一次成功、第二次失败）后，readyPath 不应指向第一次的文件。
+func TestStartDownload_ClearsPreviousReadyState(t *testing.T) {
+	f, cleanup := newTestFacadeWith404(t)
+	defer cleanup()
+
+	// 模拟上一次下载成功后残留在 facade 上的状态
+	stalePath := filepath.Join(t.TempDir(), "old-release.zip")
+	if err := os.WriteFile(stalePath, []byte("old content"), 0o644); err != nil {
+		t.Fatalf("seed stale file: %v", err)
+	}
+	f.mu.Lock()
+	f.readyPath = stalePath
+	f.readyAssetName = "old-release.zip"
+	f.mu.Unlock()
+
+	// 新一轮 StartDownload —— 这次因为 releasesURL 返回 404 一定会失败
+	if err := f.StartDownload(); err != nil {
+		t.Fatalf("StartDownload returned sync error: %v", err)
+	}
+
+	// 等待后台 goroutine 结束（clearDownloadState 会清空 downloadCancel）
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		running := f.downloadCancel != nil
+		f.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	f.mu.Lock()
+	gotPath := f.readyPath
+	gotName := f.readyAssetName
+	f.mu.Unlock()
+
+	if gotPath != "" {
+		t.Errorf("readyPath should be cleared after failed new download, got %q", gotPath)
+	}
+	if gotName != "" {
+		t.Errorf("readyAssetName should be cleared, got %q", gotName)
+	}
+	// 旧 zip 应该已经被 StartDownload 同步清理
+	if _, err := os.Stat(stalePath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("stale file should have been removed, stat err: %v", err)
+	}
+}
+
+// ApplyUpdate 在新一轮下载失败后应明确报"尚未完成下载"，而不是静默安装旧版。
+func TestApplyUpdate_AfterFailedRedownload_ReturnsNotReady(t *testing.T) {
+	f, cleanup := newTestFacadeWith404(t)
+	defer cleanup()
+
+	stalePath := filepath.Join(t.TempDir(), "old-release.zip")
+	_ = os.WriteFile(stalePath, []byte("old"), 0o644)
+
+	f.mu.Lock()
+	f.readyPath = stalePath
+	f.readyAssetName = "old-release.zip"
+	f.mu.Unlock()
+
+	_ = f.StartDownload()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		running := f.downloadCancel != nil
+		f.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	err := f.ApplyUpdate()
+	if err == nil {
+		t.Fatal("expected ApplyUpdate to error after failed redownload")
+	}
+	if err.Error() != "尚未完成下载，无法安装" {
+		t.Errorf("expected '尚未完成下载' error, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

修复 #56：\`UpdateFacade.StartDownload\` 不清理上一轮 \`readyPath\` / \`readyAssetName\`；\`doDownload\` 失败路径也不清。组合下"上次下载成功但用户没点安装 → 这次重新下载失败"时，\`ApplyUpdate\` 会读到第一次的旧路径，症状是「更新后版本没变」或「下载文件丢失」。

## 修复方案

- \`StartDownload\` 进入同步段时主动 reset \`readyPath\` / \`readyAssetName\`，并尝试 \`os.Remove\` 老临时文件（容忍失败 —— 文件可能已被系统临时目录清理）
- \`doDownload\` 的失败分支本来就会 \`os.Remove\` 当前下载的临时文件，无需额外改动
- 保持"只有成功才写 \`readyPath\`"的约定

## 测试

- [x] \`TestStartDownload_ClearsPreviousReadyState\` — 用本地 httptest 服务返回 404 模拟新下载失败；验证 \`readyPath\` / \`readyAssetName\` 均清空，且旧 zip 已从磁盘删除
- [x] \`TestApplyUpdate_AfterFailedRedownload_ReturnsNotReady\` — 同一场景下 \`ApplyUpdate\` 返回"尚未完成下载，无法安装"而非静默安装旧版
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)