### PR TITLE
fix(update): doDownload 校验 URL 前缀为本仓库 releases (#52)

### DIFF
--- a/backend/internal/facade/update_facade.go
+++ b/backend/internal/facade/update_facade.go
@@ -40,6 +40,16 @@ func NewUpdateFacade() *UpdateFacade {
 	}
 }
 
+// trustedDownloadPrefix 自更新下载 URL 必须的前缀：本仓库 releases 资源。
+// 即便 Release 的 browser_download_url 字段被篡改指向第三方域，也会被这里拦掉。
+// 不要改为可配置 —— 这条硬编码是自更新安全链的最后一道关。
+const trustedDownloadPrefix = "https://github.com/Gridea-Pro/gridea-pro/releases/download/"
+
+// isTrustedDownloadURL 校验 URL 前缀是否在白名单内。
+func isTrustedDownloadURL(url string) bool {
+	return strings.HasPrefix(url, trustedDownloadPrefix)
+}
+
 // UpdateInfo 更新检查结果
 type UpdateInfo struct {
 	HasUpdate      bool   `json:"hasUpdate"`
@@ -232,6 +242,13 @@ func (f *UpdateFacade) fetchAssetForCurrentPlatform(ctx context.Context) (*githu
 }
 
 func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, expectedSize int64) {
+	// 安全检查：即使 GitHub API 返回的 browser_download_url 被篡改（凭证泄漏 / Release 被接管 /
+	// 上游代理中间人等场景），也必须走本仓库 releases 资源前缀；其他一律拒绝下载。
+	if !isTrustedDownloadURL(url) {
+		f.emitError(fmt.Errorf("拒绝下载：非预期的更新包 URL: %s", url))
+		return
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		f.emitError(err)

--- a/backend/internal/facade/update_facade_test.go
+++ b/backend/internal/facade/update_facade_test.go
@@ -1,0 +1,63 @@
+package facade
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newWhitelistFacade() *UpdateFacade {
+	return &UpdateFacade{
+		releasesURL: "https://api.github.com/repos/Gridea-Pro/gridea-pro/releases/latest",
+		httpClient:  &http.Client{Timeout: 2 * time.Second},
+	}
+}
+
+func TestIsTrustedDownloadURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"valid_github_release", trustedDownloadPrefix + "v1.0.0/app.zip", true},
+		{"different_repo", "https://github.com/other/project/releases/download/v1.0/app.zip", false},
+		{"non_github", "https://evil.example.com/releases/download/v1.0/app.zip", false},
+		{"http_scheme", "http://github.com/Gridea-Pro/gridea-pro/releases/download/v1/a.zip", false},
+		{"prefix_only_no_path", "https://github.com/Gridea-Pro/gridea-pro/releases/download/", true},
+		{"look_alike_domain", "https://github.com.evil.com/Gridea-Pro/gridea-pro/releases/download/", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTrustedDownloadURL(tt.url)
+			if got != tt.want {
+				t.Errorf("isTrustedDownloadURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+// 非白名单 URL 必须在 doDownload 入口就被拒，不能打到网络。
+func TestDoDownload_RejectsUntrustedURL(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("fake binary"))
+	}))
+	defer srv.Close()
+
+	f := newWhitelistFacade()
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	// srv.URL 不属于 github.com/Gridea-Pro/gridea-pro/releases/download/ 前缀
+	f.doDownload(ctx, srv.URL+"/some-asset.zip", "some-asset.zip", 1024)
+
+	if n := hits.Load(); n != 0 {
+		t.Errorf("untrusted URL should not trigger HTTP request, got %d hits", n)
+	}
+}


### PR DESCRIPTION
## Summary

修复 #52（P0 security）：\`doDownload\` 直接用 GitHub API 返回的 \`browser_download_url\` 发起 HTTP GET，未校验 URL 是否指向本仓库。发包账号 token 泄漏 / CI/CD 凭证接管 / 上游代理中间人篡改任一场景下，攻击者可让本地从第三方域名拉"更新包"并被 \`installAndRelaunch\` 执行。

## 修复方案

- 新增常量 \`trustedDownloadPrefix = "https://github.com/Gridea-Pro/gridea-pro/releases/download/"\` 与 \`isTrustedDownloadURL\` 辅助函数。注释写明"不要改为可配置 —— 这条硬编码是自更新安全链的最后一道关"
- \`doDownload\` 入口做前缀校验：不匹配立即 \`emitError\` 且不发起任何 HTTP

## 选型说明

- 采用"路径前缀白名单"（issue 里的"更严格"方案），覆盖 host + 路径。"仅 host 是 github.com"太宽松，GitHub Gist / 其他仓库 release 都能通过
- 没引入 \`url.Parse\` —— 前缀匹配 + HTTPS scheme 硬编码已经足以防住域名伪装（\`https://github.com.evil.com/...\` 拿不到合法前缀）

## Test plan

- [x] \`go test ./backend/internal/facade/...\` — 7 个 \`isTrustedDownloadURL\` 子 case（含 look-alike 域名、不同仓库、http scheme、空串等）+ 1 个集成测（用 httptest 起本地服务当"攻击者域名"，验证 hit 计数保持 0）
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 人工回归：正常自更新流程仍能下载（本仓库 release 资源）

🤖 Generated with [Claude Code](https://claude.com/claude-code)