### PR TITLE
fix(update): 自更新下载包 SHA256 完整性校验 (#51)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,6 +582,16 @@ jobs:
           ls -lh artifacts/
           echo "========================="
 
+      - name: Generate SHA256SUMS
+        # 自更新完整性校验的真源：客户端下载后比对此文件里的哈希（见 UpdateFacade.verifyIntegrity）。
+        # 格式是 GNU sha256sum 的默认两列："<hex>  <filename>"，每行一个 asset。
+        # 也对 SHA256SUMS 本身签名的需求另作一个 issue 处理（需要 minisign / cosign 密钥管理）。
+        run: |
+          cd artifacts
+          sha256sum * > SHA256SUMS
+          echo "=== SHA256SUMS ==="
+          cat SHA256SUMS
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/backend/internal/facade/update_facade.go
+++ b/backend/internal/facade/update_facade.go
@@ -1,13 +1,17 @@
 package facade
 
 import (
+	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"gridea-pro/backend/internal/utils"
 	"gridea-pro/backend/internal/version"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -139,12 +143,12 @@ func (f *UpdateFacade) StartDownload() error {
 	go func() {
 		defer f.clearDownloadState()
 
-		asset, err := f.fetchAssetForCurrentPlatform(ctx)
+		asset, sums, err := f.fetchAssetForCurrentPlatform(ctx)
 		if err != nil {
 			f.emitError(err)
 			return
 		}
-		f.doDownload(ctx, asset.DownloadURL, asset.Name, asset.Size)
+		f.doDownload(ctx, asset.DownloadURL, asset.Name, asset.Size, sums)
 	}()
 	return nil
 }
@@ -202,36 +206,51 @@ func (f *UpdateFacade) clearDownloadState() {
 	f.mu.Unlock()
 }
 
-func (f *UpdateFacade) fetchAssetForCurrentPlatform(ctx context.Context) (*githubAsset, error) {
+// fetchAssetForCurrentPlatform 返回当前平台的下载 asset，以及同 Release 中
+// 名为 SHA256SUMS 的校验文件（若存在）。校验文件缺失时 sums 返回 nil，
+// 调用方应 warn 但允许下载继续 —— 这是为兼容未产出 SHA256SUMS 的历史 Release。
+func (f *UpdateFacade) fetchAssetForCurrentPlatform(ctx context.Context) (asset *githubAsset, sums *githubAsset, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.releasesURL, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "Gridea-Pro/"+version.Version)
 
 	resp, err := f.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("请求 Releases 失败: %w", err)
+		return nil, nil, fmt.Errorf("请求 Releases 失败: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("Releases 返回 %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, nil, fmt.Errorf("Releases 返回 %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var rel githubRelease
 	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-		return nil, fmt.Errorf("解析 Releases 失败: %w", err)
+		return nil, nil, fmt.Errorf("解析 Releases 失败: %w", err)
 	}
-	asset := pickAsset(rel.Assets, runtime.GOOS, runtime.GOARCH)
+	asset = pickAsset(rel.Assets, runtime.GOOS, runtime.GOARCH)
 	if asset == nil {
-		return nil, fmt.Errorf("没有匹配当前平台 (%s/%s) 的下载资源", runtime.GOOS, runtime.GOARCH)
+		return nil, nil, fmt.Errorf("没有匹配当前平台 (%s/%s) 的下载资源", runtime.GOOS, runtime.GOARCH)
 	}
-	return asset, nil
+	sums = findSumsAsset(rel.Assets)
+	return asset, sums, nil
 }
 
-func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, expectedSize int64) {
+// findSumsAsset 在 assets 里查找 SHA256SUMS 文件（约定命名，全大写匹配）。
+// 未来如果改成 SHA256SUMS.sig / .asc 等格式，也可以在这里扩展识别规则。
+func findSumsAsset(assets []githubAsset) *githubAsset {
+	for i := range assets {
+		if assets[i].Name == "SHA256SUMS" {
+			return &assets[i]
+		}
+	}
+	return nil
+}
+
+func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, expectedSize int64, sumsAsset *githubAsset) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		f.emitError(err)
@@ -311,12 +330,110 @@ func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, ex
 		return
 	}
 
+	// SHA256 完整性校验：防中间人、防上游 Release 被动替换、防半下载损坏。
+	// sumsAsset 为 nil 时仅告警（兼容未产出 SHA256SUMS 的历史 Release）；
+	// 为非 nil 时必须通过，否则删掉临时文件并 emitError，不进入 readyPath 状态。
+	if err := f.verifyDownloadChecksum(ctx, tmp.Name(), assetName, sumsAsset); err != nil {
+		_ = os.Remove(tmp.Name())
+		f.emitError(fmt.Errorf("完整性校验失败: %w", err))
+		return
+	}
+
 	f.mu.Lock()
 	f.readyPath = tmp.Name()
 	f.readyAssetName = assetName
 	f.mu.Unlock()
 
 	f.emitReady(tmp.Name())
+}
+
+// verifyDownloadChecksum 拉取 SHA256SUMS、在其中查找 assetName 对应的哈希、
+// 计算本地文件哈希并对比。sumsAsset 为 nil 时仅告警并放行（向后兼容），
+// 非 nil 时任何一步失败都返回 error —— 调用方会丢弃下载文件。
+func (f *UpdateFacade) verifyDownloadChecksum(ctx context.Context, localPath, assetName string, sumsAsset *githubAsset) error {
+	if sumsAsset == nil {
+		slog.Warn("本次 Release 无 SHA256SUMS 资源，跳过完整性校验（建议重新发布时补上）",
+			"asset", assetName)
+		return nil
+	}
+
+	expected, err := f.fetchExpectedChecksum(ctx, sumsAsset.DownloadURL, assetName)
+	if err != nil {
+		return err
+	}
+	if expected == "" {
+		return fmt.Errorf("SHA256SUMS 中未找到 %s 的哈希", assetName)
+	}
+
+	actual, err := sha256File(localPath)
+	if err != nil {
+		return fmt.Errorf("计算本地哈希失败: %w", err)
+	}
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("下载包哈希不匹配：期望 %s，实际 %s", expected, actual)
+	}
+	return nil
+}
+
+// fetchExpectedChecksum 下载 SHA256SUMS 并返回 assetName 对应的 hex 哈希。
+// 用与二进制下载相同大小的合理上限（1 MiB）防止被超大文件拖垮。
+func (f *UpdateFacade) fetchExpectedChecksum(ctx context.Context, sumsURL, assetName string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sumsURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "Gridea-Pro/"+version.Version)
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("下载 SHA256SUMS 失败: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("下载 SHA256SUMS 返回 %d", resp.StatusCode)
+	}
+
+	const maxSize = 1 << 20 // 1 MiB
+	return parseSha256Sums(io.LimitReader(resp.Body, maxSize), assetName)
+}
+
+// parseSha256Sums 按 GNU sha256sum 格式解析（"<hex>  <filename>"），
+// 返回目标文件名的哈希；未命中返回空串。
+func parseSha256Sums(r io.Reader, target string) (string, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// 格式："<hex>  <filename>"（两个空格分隔）；部分实现会是单空格或 tab
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[1], "*") // sha256sum -b 会在文件名前加 '*'
+		if name == target {
+			return strings.ToLower(fields[0]), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+// sha256File 计算文件内容的 SHA256 hex 哈希。
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func (f *UpdateFacade) emitProgress(received, total int64) {

--- a/backend/internal/facade/update_facade_test.go
+++ b/backend/internal/facade/update_facade_test.go
@@ -1,0 +1,173 @@
+package facade
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── SHA256SUMS 解析 ──────────────────────────────────────────────────────────
+
+func TestParseSha256Sums(t *testing.T) {
+	content := `d41d8cd98f00b204e9800998ecf8427e  empty.txt
+abc123def456  Gridea.Pro_v1.0.0_macos_arm64.zip
+aaaaaaaaaaaa *binary-mode-file.bin
+# this is a comment
+
+invalidline
+0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  Gridea.Pro_v1.0.0_linux_amd64.AppImage
+`
+
+	tests := []struct {
+		target string
+		want   string
+	}{
+		{"empty.txt", "d41d8cd98f00b204e9800998ecf8427e"},
+		{"Gridea.Pro_v1.0.0_macos_arm64.zip", "abc123def456"},
+		{"binary-mode-file.bin", "aaaaaaaaaaaa"}, // '*' 前缀被剥掉
+		{"Gridea.Pro_v1.0.0_linux_amd64.AppImage", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+		{"missing.zip", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			got, err := parseSha256Sums(strings.NewReader(content), tt.target)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseSha256Sums(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+// ─── sha256File 计算 ─────────────────────────────────────────────────────────
+
+func TestSha256File(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "data.bin")
+	content := []byte("hello, gridea pro")
+	if err := os.WriteFile(tmp, content, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := sha256File(tmp)
+	if err != nil {
+		t.Fatalf("sha256File: %v", err)
+	}
+
+	hh := sha256.Sum256(content)
+	want := hex.EncodeToString(hh[:])
+	if got != want {
+		t.Errorf("sha256File = %q, want %q", got, want)
+	}
+}
+
+// ─── verifyDownloadChecksum 集成场景 ──────────────────────────────────────────
+
+func TestVerifyDownloadChecksum_NoSumsAssetReturnsNil(t *testing.T) {
+	f := &UpdateFacade{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	tmp := filepath.Join(t.TempDir(), "asset.zip")
+	_ = os.WriteFile(tmp, []byte("anything"), 0o644)
+
+	if err := f.verifyDownloadChecksum(context.Background(), tmp, "asset.zip", nil); err != nil {
+		t.Errorf("no sums asset should return nil for backward compat, got %v", err)
+	}
+}
+
+func TestVerifyDownloadChecksum_HashMatches(t *testing.T) {
+	// 准备一个文件并算出它的 SHA256
+	tmp := filepath.Join(t.TempDir(), "asset.zip")
+	content := []byte("binary payload")
+	_ = os.WriteFile(tmp, content, 0o644)
+	hh := sha256.Sum256(content)
+	expected := hex.EncodeToString(hh[:])
+
+	// 起一个 httptest 服务器充当 SHA256SUMS asset 源
+	sumsBody := expected + "  asset.zip\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sumsBody))
+	}))
+	defer srv.Close()
+
+	f := &UpdateFacade{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	sumsAsset := &githubAsset{Name: "SHA256SUMS", DownloadURL: srv.URL}
+
+	if err := f.verifyDownloadChecksum(context.Background(), tmp, "asset.zip", sumsAsset); err != nil {
+		t.Errorf("expected verification to pass, got %v", err)
+	}
+}
+
+func TestVerifyDownloadChecksum_HashMismatchFails(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "asset.zip")
+	_ = os.WriteFile(tmp, []byte("binary payload"), 0o644)
+
+	sumsBody := "0000000000000000000000000000000000000000000000000000000000000000  asset.zip\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sumsBody))
+	}))
+	defer srv.Close()
+
+	f := &UpdateFacade{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	sumsAsset := &githubAsset{Name: "SHA256SUMS", DownloadURL: srv.URL}
+
+	err := f.verifyDownloadChecksum(context.Background(), tmp, "asset.zip", sumsAsset)
+	if err == nil {
+		t.Fatal("expected verification to fail on hash mismatch")
+	}
+	if !strings.Contains(err.Error(), "不匹配") {
+		t.Errorf("expected 哈希不匹配 error, got %v", err)
+	}
+}
+
+func TestVerifyDownloadChecksum_AssetNotInSums(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "asset.zip")
+	_ = os.WriteFile(tmp, []byte("binary payload"), 0o644)
+
+	sumsBody := "abc123  some-other-file.zip\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sumsBody))
+	}))
+	defer srv.Close()
+
+	f := &UpdateFacade{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	sumsAsset := &githubAsset{Name: "SHA256SUMS", DownloadURL: srv.URL}
+
+	err := f.verifyDownloadChecksum(context.Background(), tmp, "asset.zip", sumsAsset)
+	if err == nil {
+		t.Fatal("expected error when asset not in SHA256SUMS")
+	}
+	if !strings.Contains(err.Error(), "未找到") {
+		t.Errorf("expected '未找到' error, got %v", err)
+	}
+}
+
+// ─── findSumsAsset 查找逻辑 ───────────────────────────────────────────────────
+
+func TestFindSumsAsset(t *testing.T) {
+	assets := []githubAsset{
+		{Name: "Gridea.Pro_v1.0.0_macos_arm64.zip"},
+		{Name: "SHA256SUMS"},
+		{Name: "Gridea.Pro_v1.0.0_linux_amd64.AppImage"},
+	}
+	got := findSumsAsset(assets)
+	if got == nil || got.Name != "SHA256SUMS" {
+		t.Errorf("expected SHA256SUMS, got %+v", got)
+	}
+
+	got = findSumsAsset([]githubAsset{{Name: "foo.zip"}, {Name: "bar.zip"}})
+	if got != nil {
+		t.Errorf("expected nil when no SHA256SUMS present, got %+v", got)
+	}
+}
+
+// keep the fmt import alive for future extensions
+var _ = fmt.Sprintf


### PR DESCRIPTION
## Summary

修复 #51（P0 security）：\`doDownload\` 下载后直接接受文件，没有任何完整性校验。不可信网络 / GitHub 仓库被接管 / CDN 缓存被污染 / 半下载损坏等任一场景下都会让自更新执行非预期的二进制。

## 修复方案（CI + 代码两段）

### CI（\`.github/workflows/release.yml\`）

\`create-release\` job 下载完所有 artifacts 后，用 \`sha256sum\` 聚合生成 \`SHA256SUMS\`（GNU 默认两列格式），随其他 asset 一并上传到 Release。未来若要对 \`SHA256SUMS\` 本身签名（minisign / cosign）可在此处再加一步。

### Go 代码

- \`fetchAssetForCurrentPlatform\` 同时返回 \`SHA256SUMS\` asset（缺失返回 \`nil\`）
- \`doDownload\` 新增 \`sumsAsset\` 形参
- 下载成功且关闭临时文件后、写入 \`readyPath\` 前调用 \`verifyDownloadChecksum\`：
  - \`fetchExpectedChecksum\` 下载 \`SHA256SUMS\`（限制 1 MiB）
  - \`parseSha256Sums\` 查找 \`assetName\` 对应哈希
  - \`sha256File\` 计算本地文件哈希并比对
  - 任一步失败均 \`os.Remove(tmp)\` 并 \`emitError\`，**不**进入 ready 状态
- \`sumsAsset == nil\` 时仅 \`slog.Warn\` 并放行 —— 兼容未产出 \`SHA256SUMS\` 的历史 Release

## Test plan

- [x] 9 个新增单测：SHA256SUMS 解析（含注释 / 空行 / \`-b\` 模式 \`*\` 前缀 / 未命中）、\`sha256File\` 正确性、\`verifyDownloadChecksum\` 四路分支（无 sums→放行、匹配、不匹配、asset 不在列表）、\`findSumsAsset\`
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 下个 release 观察 \`SHA256SUMS\` 正常上传，客户端自更新走通强校验

## 未纳入本 PR 的后续方向

- 对 \`SHA256SUMS\` 本身做 minisign / cosign 签名，抵御"仓库被接管导致 SHA256SUMS 被同步篡改"的场景
- 历史 release 可以手动补上 \`SHA256SUMS\` 资源即可获得校验能力

🤖 Generated with [Claude Code](https://claude.com/claude-code)