### PR TITLE
fix(update): 下载瞬时错误自动重试 (#55)

### DIFF
--- a/backend/internal/facade/update_facade.go
+++ b/backend/internal/facade/update_facade.go
@@ -8,6 +8,7 @@ import (
 	"gridea-pro/backend/internal/utils"
 	"gridea-pro/backend/internal/version"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -231,11 +232,46 @@ func (f *UpdateFacade) fetchAssetForCurrentPlatform(ctx context.Context) (*githu
 	return asset, nil
 }
 
+// doDownload 对外入口：带有指数退避的自动重试。
+// 可重试错误（transient）—— 网络超时 / connection reset / 5xx / 408 / 429 —— 会重跑最多 maxDownloadAttempts - 1 次；
+// 不可重试错误 —— 4xx（除 408/429）/ URL 合法性失败 / ctx 取消 —— 立即上报。
 func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, expectedSize int64) {
+	const maxDownloadAttempts = 3
+	for attempt := 1; attempt <= maxDownloadAttempts; attempt++ {
+		err := f.tryDownload(ctx, url, assetName, expectedSize)
+		if err == nil {
+			return // tryDownload 成功时已 emitReady，无需再做其它
+		}
+
+		// 用户取消：立刻退出，不重试也不报错（CancelDownload 在前端已给出反馈）
+		if ctx.Err() != nil {
+			return
+		}
+
+		if attempt >= maxDownloadAttempts || !isTransientDownloadErr(err) {
+			f.emitError(err)
+			return
+		}
+
+		// 指数退避：1s / 2s / 4s；期间仍响应 ctx 取消
+		backoff := time.Duration(1<<(attempt-1)) * time.Second
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		// 重试开始前给前端一个明显信号：把 received 拉回 0，避免进度条在 70% 瞬间跳 0% 的惊吓
+		// （emitProgress 会计算 percent=0，前端据此可显示"重试中"文案）
+		f.emitProgress(0, expectedSize)
+	}
+}
+
+// tryDownload 执行一次完整的下载尝试。成功时写入 readyPath / readyAssetName 并 emitReady，
+// 失败时返回 error（调用方决定是否重试）。调用方负责在 ctx 取消时不要再次调用本函数。
+func (f *UpdateFacade) tryDownload(ctx context.Context, url, assetName string, expectedSize int64) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		f.emitError(err)
-		return
+		return err
 	}
 	req.Header.Set("User-Agent", "Gridea-Pro/"+version.Version)
 
@@ -243,13 +279,11 @@ func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, ex
 	dlClient := &http.Client{Timeout: 30 * time.Minute}
 	resp, err := dlClient.Do(req)
 	if err != nil {
-		f.emitError(fmt.Errorf("下载失败: %w", err))
-		return
+		return fmt.Errorf("下载失败: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		f.emitError(fmt.Errorf("下载返回 %d", resp.StatusCode))
-		return
+		return &httpStatusError{code: resp.StatusCode}
 	}
 
 	total := resp.ContentLength
@@ -259,8 +293,7 @@ func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, ex
 
 	tmp, err := os.CreateTemp("", "gridea-pro-update-*-"+sanitizeName(assetName))
 	if err != nil {
-		f.emitError(fmt.Errorf("创建临时文件失败: %w", err))
-		return
+		return fmt.Errorf("创建临时文件失败: %w", err)
 	}
 	f.mu.Lock()
 	f.downloadingFile = tmp
@@ -275,7 +308,7 @@ func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, ex
 		case <-ctx.Done():
 			_ = tmp.Close()
 			_ = os.Remove(tmp.Name())
-			return
+			return ctx.Err()
 		default:
 		}
 
@@ -284,8 +317,7 @@ func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, ex
 			if _, werr := tmp.Write(buf[:n]); werr != nil {
 				_ = tmp.Close()
 				_ = os.Remove(tmp.Name())
-				f.emitError(fmt.Errorf("写入失败: %w", werr))
-				return
+				return fmt.Errorf("写入失败: %w", werr)
 			}
 			received += int64(n)
 			if time.Now().After(nextEmit) {
@@ -299,16 +331,14 @@ func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, ex
 		if rerr != nil {
 			_ = tmp.Close()
 			_ = os.Remove(tmp.Name())
-			f.emitError(fmt.Errorf("读取失败: %w", rerr))
-			return
+			return fmt.Errorf("读取失败: %w", rerr)
 		}
 	}
 	// 最后再推一次 100%
 	f.emitProgress(received, received)
 
 	if err := tmp.Close(); err != nil {
-		f.emitError(fmt.Errorf("关闭文件失败: %w", err))
-		return
+		return fmt.Errorf("关闭文件失败: %w", err)
 	}
 
 	f.mu.Lock()
@@ -317,6 +347,48 @@ func (f *UpdateFacade) doDownload(ctx context.Context, url, assetName string, ex
 	f.mu.Unlock()
 
 	f.emitReady(tmp.Name())
+	return nil
+}
+
+// httpStatusError 表示 doDownload 收到非 2xx 响应，便于 isTransientDownloadErr
+// 区分 5xx / 408 / 429（可重试）与其它 4xx（不可重试）。
+type httpStatusError struct {
+	code int
+}
+
+func (e *httpStatusError) Error() string { return fmt.Sprintf("下载返回 %d", e.code) }
+
+// isTransientDownloadErr 判定是否属于"可能自愈"的瞬时错误，值得重试。
+// - net.Error.Timeout()       → 连接 / 读超时
+// - connection reset / EOF    → 被对端中断
+// - 5xx                        → 服务器暂时性错误
+// - 408 / 429                  → 服务器要求客户端稍后再试
+// 其它情形（4xx / URL 合法性 / 本地写入错误）不重试。
+func isTransientDownloadErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var statusErr *httpStatusError
+	if errors.As(err, &statusErr) {
+		if statusErr.code >= 500 {
+			return true
+		}
+		return statusErr.code == http.StatusRequestTimeout || statusErr.code == http.StatusTooManyRequests
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	// 兜底：字符串匹配 OS 层典型瞬时错误（避免 errors 链穿透不过带来的误判）
+	msg := err.Error()
+	return strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "EOF")
 }
 
 func (f *UpdateFacade) emitProgress(received, total int64) {

--- a/backend/internal/facade/update_facade_test.go
+++ b/backend/internal/facade/update_facade_test.go
@@ -1,0 +1,145 @@
+package facade
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestIsTransientDownloadErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"500", &httpStatusError{code: 500}, true},
+		{"502", &httpStatusError{code: 502}, true},
+		{"408", &httpStatusError{code: 408}, true},
+		{"429", &httpStatusError{code: 429}, true},
+		{"404", &httpStatusError{code: 404}, false},
+		{"401", &httpStatusError{code: 401}, false},
+		{"unexpected_eof", io.ErrUnexpectedEOF, true},
+		{"connection_reset", errors.New("read: connection reset by peer"), true},
+		{"broken_pipe", errors.New("write: broken pipe"), true},
+		{"no_such_host", errors.New("lookup evil.local: no such host"), true},
+		{"unrelated", errors.New("disk full"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientDownloadErr(tt.err)
+			if got != tt.want {
+				t.Errorf("isTransientDownloadErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// 500 服务器首两次 503，第三次 200 —— doDownload 应在第 3 次尝试拿到成功。
+func TestDoDownload_RetriesOnTransient500(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		if n < 3 {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Length", "4")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OKAY"))
+	}))
+	defer srv.Close()
+
+	f := &UpdateFacade{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		f.doDownload(ctx, srv.URL+"/asset.zip", "asset.zip", 4)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("doDownload hung")
+	}
+
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+	f.mu.Lock()
+	ready := f.readyPath
+	f.mu.Unlock()
+	if ready == "" {
+		t.Error("expected readyPath after successful retry")
+	}
+}
+
+// 4xx 非重试错误（404）应立即放弃，不再发起第二次请求。
+func TestDoDownload_NoRetryOn404(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	f := &UpdateFacade{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	f.doDownload(ctx, srv.URL+"/asset.zip", "asset.zip", 4)
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("4xx should not retry, got %d hits", got)
+	}
+}
+
+// 用户取消（ctx.Cancel）应立即终止，既不重试也不再发 HTTP 请求。
+func TestDoDownload_CancelStopsRetry(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	f := &UpdateFacade{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// 在第一次 503 之后立刻取消
+	go func() {
+		for hits.Load() < 1 {
+			time.Sleep(10 * time.Millisecond)
+		}
+		cancel()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		f.doDownload(ctx, srv.URL+"/asset.zip", "asset.zip", 4)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("doDownload did not stop after cancel")
+	}
+
+	// 应该不会完成 3 次重试（要么 1 次要么极小数，远小于 3）
+	if got := hits.Load(); got >= 3 {
+		t.Errorf("cancel should have stopped retries earlier, got %d hits", got)
+	}
+}
+
+// 确保 net 包使用不退化为 unused
+var _ = net.Listen


### PR DESCRIPTION
## Summary

修复 #55：\`doDownload\` 单次下载失败就直接 \`emitError\`，移动热点 / 公司代理 / 不稳定网络下用户体验差；release 资源体积较大时网络稍有抖动就要从头下载。

## 修复方案（方案 A：指数退避）

- 单次下载主体抽到 \`tryDownload\`，保留原有 ready / progress / 临时文件处理
- \`doDownload\` 改为重试封装：
  - 成功 → 直接返回（\`tryDownload\` 已 \`emitReady\`）
  - \`ctx\` 取消 → 静默返回（\`CancelDownload\` 已在前端给出反馈）
  - 可重试错误 + 尚有尝试次数 → **1s / 2s / 4s 指数退避**后重试
  - 不可重试或次数耗尽 → \`emitError\`
- \`isTransientDownloadErr\` 识别：\`5xx\` / \`408\` / \`429\` / \`net.Error.Timeout\` / \`io.ErrUnexpectedEOF\` / \`connection reset\` / \`broken pipe\` / \`no such host\`
- \`httpStatusError\` 作为中间错误类型，让重试策略按状态码分流
- 每次重试前 \`emitProgress(0, total)\`，给前端"重试中"的视觉信号，避免进度条从 70% 瞬间跳到 0% 带来的惊吓

未做方案 B（断点续传 \`Range\`），复杂度高且对当前资源大小（100MB 级）收益有限，留待将来单独 issue。

## Test plan

- [x] \`go test ./backend/internal/facade/...\` — 12 个 \`isTransientDownloadErr\` 子 case + 3 个集成测（\`503 x 2 → 200\` 成功重试、\`404\` 不重试、中途取消立即停）
- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：本地模拟中间 5xx 观察退避耗时 / 模拟大文件下载中断网络观察重试

🤖 Generated with [Claude Code](https://claude.com/claude-code)