### PR TITLE
fix(deploy): SFTP HostKey TOFU 校验替代 InsecureIgnoreHostKey (#37)

### DIFF
--- a/backend/internal/deploy/sftp_deployer.go
+++ b/backend/internal/deploy/sftp_deployer.go
@@ -18,11 +18,21 @@ import (
 )
 
 // SftpProvider 实现了 SFTP 文件上传部署策略
-type SftpProvider struct{}
+type SftpProvider struct {
+	// knownHostsPath 用于 TOFU 形式的 HostKey 校验；为空时走内存级 TOFU（降级）。
+	// 通过 NewSftpProviderWithKnownHosts 注入，生产路径应为 AppConfigDir/known_hosts。
+	knownHostsPath string
+}
 
-// NewSftpProvider 创建 SftpProvider
+// NewSftpProvider 创建默认 SftpProvider（无 known_hosts 持久化，仅进程内 TOFU）。
+// 生产路径请用 NewSftpProviderWithKnownHosts。
 func NewSftpProvider() *SftpProvider {
 	return &SftpProvider{}
+}
+
+// NewSftpProviderWithKnownHosts 注入 known_hosts 文件路径，启用跨会话的 HostKey 校验。
+func NewSftpProviderWithKnownHosts(knownHostsPath string) *SftpProvider {
+	return &SftpProvider{knownHostsPath: knownHostsPath}
 }
 
 // Deploy 实现 Provider 接口
@@ -62,11 +72,12 @@ func (p *SftpProvider) Deploy(ctx context.Context, outputDir string, setting *do
 		return fmt.Errorf(domain.ErrSftpConfigMissing)
 	}
 
-	// 3. SSH 连接
+	// 3. SSH 连接：使用 TOFU 形式的 HostKey 校验替代 InsecureIgnoreHostKey。
+	//    首次连接会把指纹写入 known_hosts；后续任何指纹变化都会被硬拒绝（防 MITM）。
 	sshConfig := &ssh.ClientConfig{
 		User:            username,
 		Auth:            authMethods,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: TrustOnFirstUseHostKeyCallback(p.knownHostsPath, logger),
 		Timeout:         15 * time.Second,
 	}
 

--- a/backend/internal/deploy/sftp_host_key.go
+++ b/backend/internal/deploy/sftp_host_key.go
@@ -1,0 +1,119 @@
+package deploy
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// TrustOnFirstUseHostKeyCallback 构造一个基于 known_hosts 的 SSH HostKeyCallback：
+//
+//   - 主机在 known_hosts 中且指纹匹配 → 通过
+//   - 主机在 known_hosts 中但指纹已变（可能中间人攻击）→ 硬拒绝，给出清晰
+//     的错误信息要求用户手工确认后再从 known_hosts 删除旧记录
+//   - 主机不在 known_hosts（首次连接）→ 写入 known_hosts 并通过（TOFU），
+//     同时通过 logger 告知用户当前信任的指纹，留下审计痕迹
+//
+// 相比 ssh.InsecureIgnoreHostKey 的无条件信任，此回调至少能阻断"持续性中间人"：
+// 攻击者需要在用户首次连接的那一刻就已经介入，而且任何后续替换都会立刻被发现。
+// 更严格的"首次连接前端弹窗确认指纹"的流程可在此基础上追加，不影响接口兼容。
+//
+// knownHostsPath 为空时回退到"内存级 TOFU"（只在当次进程生命周期内记录），
+// 主要用于测试与降级场景（例如磁盘权限异常），生产路径应始终传入持久化路径。
+func TrustOnFirstUseHostKeyCallback(knownHostsPath string, logger LogFunc) ssh.HostKeyCallback {
+	var inMemory sync.Map // host+fingerprint → struct{}
+	return func(host string, remote net.Addr, key ssh.PublicKey) error {
+		fp := ssh.FingerprintSHA256(key)
+
+		if knownHostsPath == "" {
+			// 内存级兜底：当次进程复连同一 host 时检查指纹一致
+			return checkOrStoreInMemory(&inMemory, host, fp, logger)
+		}
+
+		if err := ensureKnownHostsFile(knownHostsPath); err != nil {
+			if logger != nil {
+				logger(fmt.Sprintf("known_hosts 文件不可用（%v），降级为内存级 TOFU", err))
+			}
+			return checkOrStoreInMemory(&inMemory, host, fp, logger)
+		}
+
+		cb, err := knownhosts.New(knownHostsPath)
+		if err != nil {
+			return fmt.Errorf("加载 known_hosts 失败: %w", err)
+		}
+
+		kerr := cb(host, remote, key)
+		if kerr == nil {
+			return nil
+		}
+
+		// 区分两种失败：指纹变更（Want 非空，有旧记录）vs 未知主机（Want 为空）
+		var keyErr *knownhosts.KeyError
+		if errors.As(kerr, &keyErr) && len(keyErr.Want) > 0 {
+			return fmt.Errorf(
+				"SSH 主机密钥已变更（可能是中间人攻击或服务器重装）：\n"+
+					"  host=%s\n"+
+					"  新指纹=%s\n"+
+					"若确认服务器合法变更，请手工编辑 %s 删除旧记录后重试",
+				host, fp, knownHostsPath,
+			)
+		}
+
+		// 未知主机：TOFU 写入
+		if err := appendKnownHost(knownHostsPath, host, key); err != nil {
+			return fmt.Errorf("写入 known_hosts 失败: %w", err)
+		}
+		if logger != nil {
+			logger(fmt.Sprintf("🔐 首次连接 %s，已将其指纹 %s 写入 known_hosts", host, fp))
+		}
+		return nil
+	}
+}
+
+// checkOrStoreInMemory 进程内记忆式 TOFU：仅用于磁盘不可用的降级路径。
+func checkOrStoreInMemory(store *sync.Map, host, fp string, logger LogFunc) error {
+	if existing, ok := store.Load(host); ok {
+		if existing.(string) == fp {
+			return nil
+		}
+		return fmt.Errorf("本次会话中 %s 的指纹已变更（可能中间人）：旧 %s → 新 %s", host, existing, fp)
+	}
+	store.Store(host, fp)
+	if logger != nil {
+		logger(fmt.Sprintf("⚠️ known_hosts 不可用，内存级 TOFU 记录 %s 指纹 %s（重启后失效）", host, fp))
+	}
+	return nil
+}
+
+// ensureKnownHostsFile 确保 known_hosts 文件及其父目录存在，不存在则创建空文件。
+func ensureKnownHostsFile(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// appendKnownHost 以 OpenSSH 兼容的格式追加一条 host 记录。
+func appendKnownHost(path, host string, key ssh.PublicKey) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	line := knownhosts.Line([]string{knownhosts.Normalize(host)}, key)
+	if _, err := fmt.Fprintln(f, line); err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/deploy/sftp_host_key_test.go
+++ b/backend/internal/deploy/sftp_host_key_test.go
@@ -1,0 +1,137 @@
+package deploy
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// mkPublicKey 返回一个一次性的 ed25519 ssh.PublicKey 用于测试。
+func mkPublicKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ed25519: %v", err)
+	}
+	sshKey, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("new ssh key: %v", err)
+	}
+	return sshKey
+}
+
+func dummyAddr(t *testing.T) net.Addr {
+	t.Helper()
+	addr, _ := net.ResolveTCPAddr("tcp", "1.2.3.4:22")
+	return addr
+}
+
+func TestTOFU_FirstConnectTrustsAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+
+	var logs []string
+	logger := func(msg string) { logs = append(logs, msg) }
+
+	cb := TrustOnFirstUseHostKeyCallback(path, logger)
+	key := mkPublicKey(t)
+
+	if err := cb("example.com:22", dummyAddr(t), key); err != nil {
+		t.Fatalf("first connect should trust, got %v", err)
+	}
+
+	// 文件应已创建并包含一行指纹
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read known_hosts: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("known_hosts should not be empty after TOFU")
+	}
+	if !strings.Contains(strings.Join(logs, "\n"), "首次连接") {
+		t.Errorf("expected 首次连接 log, got %v", logs)
+	}
+}
+
+func TestTOFU_SecondConnectWithSameKeyAccepted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+	cb := TrustOnFirstUseHostKeyCallback(path, nil)
+	key := mkPublicKey(t)
+
+	if err := cb("host.example.com:22", dummyAddr(t), key); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// 第二次连接相同 key 必须通过
+	if err := cb("host.example.com:22", dummyAddr(t), key); err != nil {
+		t.Errorf("second connect should succeed, got %v", err)
+	}
+}
+
+func TestTOFU_FingerprintChangeRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+	cb := TrustOnFirstUseHostKeyCallback(path, nil)
+
+	key1 := mkPublicKey(t)
+	key2 := mkPublicKey(t)
+
+	if err := cb("foo.example.com:22", dummyAddr(t), key1); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// 指纹变化：必须硬拒绝
+	err := cb("foo.example.com:22", dummyAddr(t), key2)
+	if err == nil {
+		t.Fatal("expected rejection when host key changes, got nil")
+	}
+	if !strings.Contains(err.Error(), "主机密钥已变更") {
+		t.Errorf("expected 主机密钥已变更 error, got %v", err)
+	}
+}
+
+func TestTOFU_FallsBackToInMemoryWhenPathEmpty(t *testing.T) {
+	cb := TrustOnFirstUseHostKeyCallback("", nil)
+	key1 := mkPublicKey(t)
+	key2 := mkPublicKey(t)
+
+	if err := cb("bar.example.com:22", dummyAddr(t), key1); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := cb("bar.example.com:22", dummyAddr(t), key1); err != nil {
+		t.Errorf("same key replay should succeed, got %v", err)
+	}
+	if err := cb("bar.example.com:22", dummyAddr(t), key2); err == nil {
+		t.Error("expected in-memory TOFU to reject fingerprint change")
+	}
+}
+
+// 不同 host 互不影响
+func TestTOFU_DifferentHostsIsolated(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+	cb := TrustOnFirstUseHostKeyCallback(path, nil)
+
+	keyA := mkPublicKey(t)
+	keyB := mkPublicKey(t)
+
+	if err := cb("a.example.com:22", dummyAddr(t), keyA); err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	// 新的 host 即使 key 完全不同也应被 TOFU 接受
+	if err := cb("b.example.com:22", dummyAddr(t), keyB); err != nil {
+		t.Errorf("unrelated new host should be TOFU-trusted, got %v", err)
+	}
+	// 各自复连仍应通过
+	if err := cb("a.example.com:22", dummyAddr(t), keyA); err != nil {
+		t.Errorf("a second connect: %v", err)
+	}
+	if err := cb("b.example.com:22", dummyAddr(t), keyB); err != nil {
+		t.Errorf("b second connect: %v", err)
+	}
+}

--- a/backend/internal/facade/app.go
+++ b/backend/internal/facade/app.go
@@ -126,6 +126,8 @@ func NewAppServices(appDir string, assets embed.FS) *AppServices {
 	deployService.SetCdnUploadService(cdnUploadService)
 	deployService.SetRenderer(rendererService)
 	deployService.SetOAuthService(oauthService)
+	// SFTP HostKey TOFU 校验文件位置：app 级目录跨站点共享（#37）
+	deployService.SetKnownHostsPath(filepath.Join(cm.AppConfigDir(), "known_hosts"))
 	aiService := service.NewAIService(aiSettingRepo, settingRepo, aiUsageRepo)
 
 	// 3. Wrap with Facades

--- a/backend/internal/service/deploy_service.go
+++ b/backend/internal/service/deploy_service.go
@@ -19,6 +19,7 @@ type DeployService struct {
 	cdnUploadService *CdnUploadService
 	oauthService     *OAuthService // 用于从 Keychain 补全凭证
 	appDir           string
+	knownHostsPath   string // SFTP HostKey TOFU 校验文件路径（跨站点共享，见 #37）
 	mu               sync.Mutex
 	isDeploying      bool
 }
@@ -28,6 +29,12 @@ func NewDeployService(settingRepo domain.SettingRepository, appDir string) *Depl
 		settingRepo: settingRepo,
 		appDir:      appDir,
 	}
+}
+
+// SetKnownHostsPath 注入 known_hosts 路径，生产环境应在 bootstrap 时设置为
+// AppConfigDir/known_hosts，以便 SFTP Provider 做 HostKey TOFU 校验。
+func (s *DeployService) SetKnownHostsPath(path string) {
+	s.knownHostsPath = path
 }
 
 // SetOAuthService 注入 OAuthService（用于从 Keychain 读取凭证）
@@ -124,7 +131,7 @@ func (s *DeployService) DeployToRemote(ctx context.Context) error {
 		if setting.TransferProtocol() == "ftp" {
 			provider = deploy.NewFtpProvider()
 		} else {
-			provider = deploy.NewSftpProvider()
+			provider = deploy.NewSftpProviderWithKnownHosts(s.knownHostsPath)
 		}
 	default:
 		provider = deploy.NewGitProvider()


### PR DESCRIPTION
## Summary

修复 #37（P0 security）：\`sftp_deployer\` 原用 \`ssh.InsecureIgnoreHostKey()\` 无条件信任服务器公钥。LAN / 公共 WiFi / 运营商劫持任一场景下攻击者都能静默冒充 SFTP 服务器，拦截密码 / 私钥 / 全站内容，用户完全无感。

## 修复方案（TOFU + known_hosts）

采用 Trust-on-First-Use 策略，基于 \`golang.org/x/crypto/ssh/knownhosts\`：

| 场景 | 行为 |
|---|---|
| 主机已在 known_hosts 且指纹匹配 | ✅ 通过 |
| 主机已在 known_hosts 但**指纹变了** | ❌ **硬拒绝**，给出"可能 MITM"错误 + 修复步骤 |
| 未知主机（首次） | ✅ 写入 known_hosts + logger 通知指纹 |
| known_hosts 路径为空 / 不可写 | 降级为进程内 TOFU（仅本次会话有效） |

相比 \`InsecureIgnoreHostKey\` 的无条件信任：**任何持续性 MITM 都会在第二次连接时被识别并阻断**。攻击窗口收窄到"首次连接的那一刻"。

## 注入链路

- \`NewSftpProviderWithKnownHosts(path)\` 构造器；原 \`NewSftpProvider()\` 保留为空路径版本
- \`DeployService.SetKnownHostsPath\` 方法
- \`facade/app.go\` 在 bootstrap 时注入 \`AppConfigDir/known_hosts\`（跨站点共享）

## 未做的后续（建议独立 issue）

issue 里提到的"首次连接弹窗显示指纹让用户手动确认"需要 Wails 事件 + 前端 modal + Promise 等待机制，复杂度较高。本 PR 先封堵"无条件信任 + MITM 无感"这条最危险路径；UI 确认是可在当前回调接口上追加的改进，不会冲突。

## Test plan

- [x] 5 个新增单测：首次 TOFU 持久化、复连通过、指纹变更硬拒、path 空降级、多 host 互不影响
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 人工回归：
  - 首次 SFTP 部署观察日志"首次连接 xxx，已将其指纹 ... 写入 known_hosts"
  - 同一台服务器重装 SSH（指纹变化）后再部署，应收到"主机密钥已变更"硬拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)