### PR TITLE
fix(deploy): FTP 支持 FTPS，对明文 FTP 强警告 (#38)

### DIFF
--- a/backend/internal/deploy/ftp_deployer.go
+++ b/backend/internal/deploy/ftp_deployer.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"os"
@@ -22,6 +23,16 @@ type FtpProvider struct{}
 func NewFtpProvider() *FtpProvider {
 	return &FtpProvider{}
 }
+
+// FTP 模式常量：对应 setting.ftpMode 字段。
+const (
+	ftpModePlain         = "ftp"            // 明文（不安全），仅为兼容老配置保留
+	ftpModeExplicitTLS   = "ftps-explicit"  // 推荐：先建立 TCP，再 AUTH TLS 升级
+	ftpModeImplicitTLS   = "ftps-implicit"  // 首包就是 TLS（通常 990 端口）
+	plainFTPInsecureWarn = "⚠️ 警告：当前使用明文 FTP。用户名、密码和所有上传内容将以明文形式在网络上传输，\n" +
+		"   任何可以嗅探链路的中间节点（公共 WiFi / 运营商 / 被攻陷的路由器）都能直接获取。\n" +
+		"   强烈建议切换到 SFTP 或 FTPS（在平台设置里选择 \"ftps-explicit\"）。"
+)
 
 // Deploy 实现 Provider 接口
 // 流程：FTP 连接 → 登录 → 清理远程目录 → 上传文件
@@ -58,9 +69,33 @@ func (p *FtpProvider) Deploy(ctx context.Context, outputDir string, setting *dom
 
 	// 2. FTP 连接
 	addr := fmt.Sprintf("%s:%d", server, port)
-	logger(fmt.Sprintf("正在连接 %s ...", addr))
+	mode := setting.FtpMode()
+	if mode == "" {
+		mode = ftpModePlain
+	}
+	logger(fmt.Sprintf("正在连接 %s (模式: %s) ...", addr, mode))
 
-	conn, err := ftp.Dial(addr, ftp.DialWithTimeout(15*time.Second))
+	dialOpts := []ftp.DialOption{ftp.DialWithTimeout(15 * time.Second)}
+	switch mode {
+	case ftpModeExplicitTLS, ftpModeImplicitTLS:
+		tlsCfg := &tls.Config{
+			ServerName:         server,
+			InsecureSkipVerify: setting.AllowInsecureTLS(),
+		}
+		if tlsCfg.InsecureSkipVerify {
+			logger("⚠️ 已启用\"允许不安全 TLS\"，服务端证书不会被校验，仅建议 NAS 自签场景使用")
+		}
+		if mode == ftpModeExplicitTLS {
+			dialOpts = append(dialOpts, ftp.DialWithExplicitTLS(tlsCfg))
+		} else {
+			dialOpts = append(dialOpts, ftp.DialWithTLS(tlsCfg))
+		}
+	default:
+		// 明文 FTP：给用户醒目警告，凭证与内容将以明文传输
+		logger(plainFTPInsecureWarn)
+	}
+
+	conn, err := ftp.Dial(addr, dialOpts...)
 	if err != nil {
 		return fmt.Errorf("FTP 连接失败: %w", err)
 	}

--- a/backend/internal/domain/ftp_mode_test.go
+++ b/backend/internal/domain/ftp_mode_test.go
@@ -1,0 +1,54 @@
+package domain
+
+import "testing"
+
+func TestFtpMode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  map[string]any
+		want string
+	}{
+		{"missing", nil, ""},
+		{"explicit", map[string]any{"ftpMode": "ftps-explicit"}, "ftps-explicit"},
+		{"implicit", map[string]any{"ftpMode": "ftps-implicit"}, "ftps-implicit"},
+		{"plain", map[string]any{"ftpMode": "ftp"}, "ftp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Setting{Platform: "sftp"}
+			if tt.cfg != nil {
+				s.PlatformConfigs = map[string]map[string]any{"sftp": tt.cfg}
+			}
+			if got := s.FtpMode(); got != tt.want {
+				t.Errorf("FtpMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowInsecureTLS(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  map[string]any
+		want bool
+	}{
+		{"missing", nil, false},
+		{"bool_true", map[string]any{"allowInsecureTLS": true}, true},
+		{"bool_false", map[string]any{"allowInsecureTLS": false}, false},
+		{"string_true", map[string]any{"allowInsecureTLS": "true"}, true},
+		{"string_1", map[string]any{"allowInsecureTLS": "1"}, true},
+		{"string_false", map[string]any{"allowInsecureTLS": "false"}, false},
+		{"empty", map[string]any{"allowInsecureTLS": ""}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Setting{Platform: "sftp"}
+			if tt.cfg != nil {
+				s.PlatformConfigs = map[string]map[string]any{"sftp": tt.cfg}
+			}
+			if got := s.AllowInsecureTLS(); got != tt.want {
+				t.Errorf("AllowInsecureTLS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/domain/setting.go
+++ b/backend/internal/domain/setting.go
@@ -88,7 +88,7 @@ var platformFieldOrder = map[string][]string{
 	"coding":  {"domain", "repository", "branch", "username", "email", "tokenUsername", "token", "cname"},
 	"netlify": {"domain", "netlifySiteId", "netlifyAccessToken"},
 	"vercel":  {"domain", "repository", "token", "cname"},
-	"sftp":    {"domain", "transferProtocol", "server", "port", "username", "password", "privateKey", "remotePath"},
+	"sftp":    {"domain", "transferProtocol", "ftpMode", "allowInsecureTLS", "server", "port", "username", "password", "privateKey", "remotePath"},
 }
 
 // MarshalJSON 自定义 JSON 序列化，确保平台配置项按前端表单顺序输出
@@ -275,6 +275,35 @@ func (s *Setting) RemotePath() string { return s.Get("remotePath") }
 
 // TransferProtocol 当前平台的传输协议（sftp 或 ftp）
 func (s *Setting) TransferProtocol() string { return s.Get("transferProtocol") }
+
+// FtpMode 当 TransferProtocol=="ftp" 时决定是否叠加 TLS：
+//
+//   - "ftps-explicit"：连接后发送 AUTH TLS 升级到 TLS（21 端口）—— 推荐
+//   - "ftps-implicit"：直接用 TLS 建立连接（通常走 990 端口）
+//   - "ftp" 或空：明文（不安全，仅兼容老配置）
+//
+// 空值按"ftp"处理，保持向后兼容。
+func (s *Setting) FtpMode() string { return s.Get("ftpMode") }
+
+// AllowInsecureTLS 当启用 FTPS 时是否允许自签/无效证书。默认 false；仅在
+// 用户 NAS 自签场景显式开启。在前端设置表单里对应一个"允许不安全证书"开关。
+func (s *Setting) AllowInsecureTLS() bool {
+	// 宽松解析字符串形式的 bool（前端 Select / Switch 可能落成 "true" / "1" / 布尔）
+	v := s.Get("allowInsecureTLS")
+	if v == "true" || v == "1" {
+		return true
+	}
+	// 也支持直接存 bool 的历史/兼容路径
+	if s.PlatformConfigs == nil {
+		return false
+	}
+	if cfg, ok := s.PlatformConfigs[s.Platform]; ok {
+		if b, ok := cfg["allowInsecureTLS"].(bool); ok {
+			return b
+		}
+	}
+	return false
+}
 
 // Validate 校验配置数据
 func (s *Setting) Validate() error {

--- a/frontend/src/views/settings/components/BasicSetting.vue
+++ b/frontend/src/views/settings/components/BasicSetting.vue
@@ -377,6 +377,29 @@
                 </SelectContent>
               </Select>
             </FormField>
+            <!-- FTP 加密模式：仅当选择 FTP 时可见 -->
+            <FormField v-if="drawerForm.transferProtocol === 'ftp'" label="FTP 加密模式">
+              <Select :model-value="drawerForm.ftpMode || 'ftps-explicit'" @update:model-value="drawerForm.ftpMode = $event">
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ftps-explicit">FTPS（显式 TLS，推荐）</SelectItem>
+                  <SelectItem value="ftps-implicit">FTPS（隐式 TLS / 990 端口）</SelectItem>
+                  <SelectItem value="ftp">明文 FTP（不安全）</SelectItem>
+                </SelectContent>
+              </Select>
+              <template v-if="drawerForm.ftpMode === 'ftp'" #hint>
+                <span class="text-red-500">⚠️ 明文 FTP 会泄漏密码和站点内容，仅供内网测试</span>
+              </template>
+            </FormField>
+            <FormField v-if="drawerForm.transferProtocol === 'ftp' && (drawerForm.ftpMode === 'ftps-explicit' || drawerForm.ftpMode === 'ftps-implicit')"
+              label="允许不安全 TLS 证书">
+              <Switch :checked="!!drawerForm.allowInsecureTLS" @update:checked="drawerForm.allowInsecureTLS = $event" />
+              <template #hint>
+                <span>仅在 NAS 自签证书等受控场景下开启；默认关闭</span>
+              </template>
+            </FormField>
             <FormField :label="t('settings.network.server')">
               <Input v-model="drawerForm.server" placeholder="192.168.1.100" />
             </FormField>
@@ -551,6 +574,8 @@ const drawerForm = reactive<Record<string, any>>({
   token: '',
   cname: '',
   transferProtocol: 'sftp',
+  ftpMode: 'ftps-explicit',
+  allowInsecureTLS: false,
   port: '',
   server: '',
   password: '',
@@ -930,7 +955,7 @@ function buildSettingForPlatform(platformId: string) {
     coding: ['domain', 'repository', 'branch', 'username', 'email', 'tokenUsername', 'token', 'cname'],
     netlify: ['domain', 'netlifySiteId', 'netlifyAccessToken'],
     vercel: ['domain', 'repository', 'token', 'cname'],
-    sftp: ['domain', 'transferProtocol', 'server', 'port', 'username', 'password', 'privateKey', 'remotePath'],
+    sftp: ['domain', 'transferProtocol', 'ftpMode', 'allowInsecureTLS', 'server', 'port', 'username', 'password', 'privateKey', 'remotePath'],
   }
 
   const fields = platformFieldMap[platformId] || []
@@ -938,6 +963,9 @@ function buildSettingForPlatform(platformId: string) {
   for (const f of fields) {
     if (f === 'domain') {
       cfg.domain = domain
+    } else if (f === 'allowInsecureTLS') {
+      // 保留为 bool，不要强转空串
+      cfg[f] = !!drawerForm[f]
     } else {
       cfg[f] = drawerForm[f] || ''
     }


### PR DESCRIPTION
## Summary

修复 #38（P0 security）：\`ftp_deployer\` 原只走 \`ftp.Dial\` 明文连接 —— 密码与站点内容全程以明文传输，链路上任何嗅探点都能拿到。

## 修复方案

### 后端

- \`domain.Setting\` 新增 \`FtpMode()\` / \`AllowInsecureTLS()\`
  - \`ftpMode\`: \`ftps-explicit\` / \`ftps-implicit\` / \`ftp\`（空串兼容老配置 = 明文）
  - \`allowInsecureTLS\`: bool，允许自签证书（默认 false，仅 NAS 场景）
  - \`platformFieldOrder.sftp\` 纳入新字段以保持 JSON 序列化顺序稳定
- \`ftp_deployer\` 按 \`ftpMode\` 分支：
  - \`ftps-explicit\` → \`ftp.DialWithExplicitTLS\`（推荐，21 端口）
  - \`ftps-implicit\` → \`ftp.DialWithTLS\`（990 端口）
  - \`ftp\` / 空串 → 明文，并打印大幅警告条，告知"任何嗅探点都能拿到密码和站点内容"
  - \`AllowInsecureTLS = true\` 时额外警告"证书不会被校验"

### 前端

- \`BasicSetting.vue\` 在"传输协议 = FTP"时显示：
  - 加密模式下拉（默认 \`ftps-explicit\`）
  - "允许不安全 TLS" 开关（仅 FTPS 模式可见，默认关）
- \`platformFieldMap[sftp]\` 纳入新字段以保证保存时写入后端
- 明文选项带红字警告"仅供内网测试"

## 未纳入本 PR

- 12 个 i18n 文件的本地化（当前新 label 用中文硬编码让功能可用）—— 独立 PR 补全，不阻塞安全修复落地

## Test plan

- [x] 11 个新增单测：\`FtpMode\` 4 变体、\`AllowInsecureTLS\` 7 个（bool / 字符串 / 空串 宽松解析）
- [x] \`go build ./backend/...\` / \`go vet ./backend/...\` 通过
- [ ] 人工回归：
  - 选 ftps-explicit 连接 vsftpd 启用 TLS 的服务器
  - 选明文 FTP 部署时日志有醒目警告
  - 旧配置（无 ftpMode 字段）走明文兼容，且警告正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)