### PR TITLE
fix(deploy): DeployToRemote 总超时控制 30min，避免永久占锁 (#49)

### DIFF
--- a/backend/internal/service/deploy_service.go
+++ b/backend/internal/service/deploy_service.go
@@ -9,9 +9,16 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
+
+// defaultDeployTimeout 单次部署的总超时上限，超过就强制取消。
+// 30 分钟对绝大多数站点（含大文件 CDN 上传）足够宽松，同时保证 deploy 卡死
+// 不会无限占用互斥锁 —— 即便 provider 某个阻塞点对 ctx 不敏感，HTTP
+// 请求 / 网络 I/O 也会在 ctx 超时后被 Transport 取消。
+const defaultDeployTimeout = 30 * time.Minute
 
 type DeployService struct {
 	settingRepo      domain.SettingRepository
@@ -60,6 +67,16 @@ func (s *DeployService) DeployToRemote(ctx context.Context) error {
 		s.isDeploying = false
 		s.mu.Unlock()
 	}()
+
+	// 总超时控制（issue #49）：
+	// 1) 部分 provider 在非 HTTP 的阻塞点（SFTP io.Copy / FTP Stor）对 ctx 不敏感，
+	//    没有总 timeout 就会永远占用互斥锁，直到进程重启
+	// 2) WailsContext 在正常运行期间永远不 Done，不能靠外部取消兜底
+	// 每个 provider 内部的 HTTP 请求通过 NewRequestWithContext 继承这个 ctx，
+	// 超时后会被 Transport 层主动取消，释放 goroutine。
+	deployCtx, cancel := context.WithTimeout(ctx, defaultDeployTimeout)
+	defer cancel()
+	ctx = deployCtx
 
 	s.log(ctx, "Starting deployment check...")
 


### PR DESCRIPTION
## Summary

修复 #49：\`DeployToRemote\` 直接把 \`WailsContext\`（永远不 Done）传给 provider。SFTP 的 \`io.Copy\` / FTP 的 \`Stor\` 等非 HTTP 阻塞点对 ctx 不敏感 —— 底层网络 hang 时会永远阻塞，\`isDeploying\` 保持 \`true\`，后续部署请求全被 \`ErrDeployInProgress\` 拒绝直到进程重启。

## 修复方案（本 PR 聚焦最直接的"永久占锁"）

- \`DeployToRemote\` 入口用 \`context.WithTimeout(ctx, 30min)\` 重新包裹
- \`defer cancel()\` 防泄漏
- 超时到达后：
  - HTTP 请求会被 Transport 层主动取消
  - SFTP / FTP 的 \`defer conn.Close()\` 触发底层连接关闭，打断阻塞
- \`defaultDeployTimeout\` 做常量，方便未来按站点设置读取

## 未纳入本 PR（issue 里覆盖的更大话题）

issue #49 同时提出了两个更深的改造，都更大、风险也更大，独立推进：

1. **HTTP client 改造**：把 \`http.Client.Timeout\` 拆成 \`DialContext\` / \`TLSHandshakeTimeout\` / \`ResponseHeaderTimeout\`，避免 60s 一刀切误杀大文件上传
2. **ctx-aware io.Copy**：在 SFTP/FTP 的大块 \`io.Copy\` 循环中每 64KB 检查一次 ctx，让长时间传输也能被及时取消

## Test plan

- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：
  - 正常部署应在 30 分钟内完成（足够宽松）
  - 手动 kill -STOP 服务器进程构造 SFTP hang 场景，30 分钟后会自动释放锁（而不是永久占锁）
  - 普通大文件上传不受影响（HTTP client.Timeout 改造是另一个 PR 的事）

🤖 Generated with [Claude Code](https://claude.com/claude-code)