### PR TITLE
fix(cdn): 上传失败显式汇总与阈值阻断 (#44)

### DIFF
--- a/backend/internal/service/cdn_upload_service.go
+++ b/backend/internal/service/cdn_upload_service.go
@@ -296,15 +296,33 @@ func (s *CdnUploadService) TestUpload(ctx context.Context) (string, error) {
 	return cdnURL, nil
 }
 
-// UploadMediaForDeploy 部署时扫描并上传媒体文件到 CDN
-func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir string, logger func(string)) error {
+// UploadFailure 描述一次 CDN 上传失败，用于汇总向上报告（见 UploadResult）。
+type UploadFailure struct {
+	Path  string // 相对仓库根的远程路径（例如 "post-images/cover.png"）
+	Error string // 人类可读错误（已脱敏，不包含 token）
+}
+
+// UploadResult 汇总 CDN 批量上传的结果。
+// 调用方据此决定是否中止部署 / 展示失败列表。
+type UploadResult struct {
+	Total    int
+	Success  int
+	Failures []UploadFailure
+}
+
+// UploadMediaForDeploy 部署时扫描并上传媒体文件到 CDN。
+// 返回 UploadResult 供调用方做失败汇总 / 阈值判断；error 仅用于"整体流程失败"
+// （如读配置失败）。单文件失败会计入 Failures 但不直接返回 error。
+func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir string, logger func(string)) (UploadResult, error) {
+	var res UploadResult
+
 	setting, err := s.cdnSettingRepo.GetCdnSetting(ctx)
 	if err != nil {
-		return fmt.Errorf("读取 CDN 配置失败: %w", err)
+		return res, fmt.Errorf("读取 CDN 配置失败: %w", err)
 	}
 
 	if !setting.Enabled || setting.GithubToken == "" {
-		return nil
+		return res, nil
 	}
 
 	// 需要扫描的目录
@@ -348,18 +366,21 @@ func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir stri
 		}
 	}
 
-	if len(filesToUpload) == 0 {
+	res.Total = len(filesToUpload)
+	if res.Total == 0 {
 		logger("没有需要上传的媒体文件")
-		return nil
+		return res, nil
 	}
 
-	logger(fmt.Sprintf("发现 %d 个媒体文件，开始上传到 CDN...", len(filesToUpload)))
+	logger(fmt.Sprintf("发现 %d 个媒体文件，开始上传到 CDN...", res.Total))
 
-	// 使用 errgroup 控制并发（限制 5 并发）
+	// 使用 errgroup 控制并发（限制 5 并发）。
+	// 单文件失败不终止 errgroup（保持"尽量完成"语义），但会被收集到 failures 列表。
 	g, gCtx := errgroup.WithContext(ctx)
 	sem := make(chan struct{}, 5)
-	var uploadCount int
 	var mu sync.Mutex
+	var failures []UploadFailure
+	var successCount int
 
 	for _, file := range filesToUpload {
 		f := file
@@ -369,22 +390,42 @@ func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir stri
 
 			if err := s.uploadToGitHub(gCtx, setting, f.localPath, f.remotePath); err != nil {
 				logger(fmt.Sprintf("上传 %s 失败: %v", f.remotePath, err))
+				mu.Lock()
+				failures = append(failures, UploadFailure{Path: f.remotePath, Error: err.Error()})
+				mu.Unlock()
 				return nil // 单个文件失败不中断整个上传
 			}
 
 			mu.Lock()
-			uploadCount++
+			successCount++
 			mu.Unlock()
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("上传媒体文件失败: %w", err)
+		return res, fmt.Errorf("上传媒体文件失败: %w", err)
 	}
 
-	logger(fmt.Sprintf("CDN 上传完成，共上传 %d 个文件", uploadCount))
-	return nil
+	res.Success = successCount
+	res.Failures = failures
+
+	if len(failures) == 0 {
+		logger(fmt.Sprintf("CDN 上传完成，共上传 %d 个文件", res.Success))
+	} else {
+		logger(fmt.Sprintf("CDN 上传完成：成功 %d / 总数 %d（失败 %d 个，详见下方列表）",
+			res.Success, res.Total, len(failures)))
+		// 摘要列出头几条失败，避免把日志撑爆；调用方会拿到完整 Failures 做决策
+		const previewN = 5
+		for i, f := range failures {
+			if i >= previewN {
+				logger(fmt.Sprintf("  ...（其余 %d 个失败未列出）", len(failures)-previewN))
+				break
+			}
+			logger(fmt.Sprintf("  ✗ %s: %s", f.Path, f.Error))
+		}
+	}
+	return res, nil
 }
 
 // buildCdnURL 构建 CDN 访问 URL

--- a/backend/internal/service/deploy_service.go
+++ b/backend/internal/service/deploy_service.go
@@ -87,13 +87,20 @@ func (s *DeployService) DeployToRemote(ctx context.Context) error {
 		s.log(ctx, "Warning: Renderer service not attached, skipping build.")
 	}
 
-	// 2.5 CDN 上传媒体文件
+	// 2.5 CDN 上传媒体文件。
+	// 单文件失败不终止整组，UploadMediaForDeploy 返回 UploadResult 汇总成功 / 失败清单。
+	// 失败占比超过阈值时中止部署，避免"toast 成功、线上图片大面积 404"的隐性故障（#44）。
 	if s.cdnUploadService != nil {
 		s.log(ctx, "Uploading media files to CDN...")
-		if err := s.cdnUploadService.UploadMediaForDeploy(ctx, s.appDir, func(msg string) {
+		result, err := s.cdnUploadService.UploadMediaForDeploy(ctx, s.appDir, func(msg string) {
 			s.log(ctx, msg)
-		}); err != nil {
+		})
+		if err != nil {
 			s.log(ctx, fmt.Sprintf("CDN upload warning: %v", err))
+		}
+		if reason := cdnFailureAbortReason(result); reason != "" {
+			s.log(ctx, fmt.Sprintf("❌ %s，已中止部署以避免上线图片 404", reason))
+			return fmt.Errorf("CDN 上传失败率过高：%s", reason)
 		}
 	}
 
@@ -149,3 +156,36 @@ func (s *DeployService) log(ctx context.Context, msg string) {
 		runtime.EventsEmit(ctx, "deploy-log", msg)
 	}
 }
+
+// cdn 上传失败阈值：超过任一条件都视为"过多"，部署中止。
+// 比例偏保守（10%），绝对数给定下限（5）避免小图库被 1~2 个误差锁死。
+const (
+	cdnFailureRatioThreshold = 0.10
+	cdnFailureAbsoluteCap    = 5
+)
+
+// cdnFailureAbortReason 判断是否因 CDN 上传失败过多而中止部署。
+// 返回空串表示可以继续；返回非空表示应中止，字符串即用户友好原因。
+func cdnFailureAbortReason(r CdnUploadResultShape) string {
+	if r.GetTotal() == 0 || len(r.GetFailures()) == 0 {
+		return ""
+	}
+	failed := len(r.GetFailures())
+	ratio := float64(failed) / float64(r.GetTotal())
+	if ratio >= cdnFailureRatioThreshold && failed >= cdnFailureAbsoluteCap {
+		return fmt.Sprintf("%d 个文件失败（共 %d 个，占比 %.0f%%）", failed, r.GetTotal(), ratio*100)
+	}
+	return ""
+}
+
+// CdnUploadResultShape 是对 UploadResult 的抽象，用于在不跨包循环依赖的前提下
+// 在 service 包里做阈值判断。具体类型为 *UploadResult。
+type CdnUploadResultShape interface {
+	GetTotal() int
+	GetFailures() []UploadFailure
+}
+
+// 让 UploadResult 满足 CdnUploadResultShape —— 方法放这里是为了让阈值函数能在
+// 同一个 service 包内引用，不需要暴露到 domain 层。
+func (r UploadResult) GetTotal() int                 { return r.Total }
+func (r UploadResult) GetFailures() []UploadFailure  { return r.Failures }

--- a/backend/internal/service/deploy_service_cdn_test.go
+++ b/backend/internal/service/deploy_service_cdn_test.go
@@ -1,0 +1,56 @@
+package service
+
+import "testing"
+
+func TestCdnFailureAbortReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		total  int
+		failed int
+		abort  bool
+	}{
+		// 没有文件：放行
+		{"no_files", 0, 0, false},
+		// 全成功：放行
+		{"all_success", 10, 0, false},
+		// 少量失败，未达绝对下限：放行
+		{"few_failures_below_cap", 100, 3, false},
+		// 满足"绝对下限 5" 但比例不够 10%（50 失败/1000 = 5%）—— 放行
+		// 注意：要求比例 >= 10% AND 绝对数 >= 5。
+		{"high_total_low_ratio", 1000, 5, false}, // 0.5%，比例不达
+		// 满足比例但未达绝对下限（5 失败/50 = 10%，绝对 < 5 的等价边界：4 失败/40 = 10%）
+		{"ratio_ok_abs_low", 40, 4, false}, // 绝对 4 < 5，放行
+		// 比例和绝对数都达标：中止
+		{"ratio_and_abs_over", 50, 5, true}, // 10%，绝对 5
+		// 大量失败：中止
+		{"half_fail", 20, 10, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := UploadResult{Total: tt.total}
+			r.Failures = make([]UploadFailure, tt.failed)
+			got := cdnFailureAbortReason(r)
+			if (got != "") != tt.abort {
+				t.Errorf("cdnFailureAbortReason(total=%d, failed=%d) = %q, want abort=%v",
+					tt.total, tt.failed, got, tt.abort)
+			}
+		})
+	}
+}
+
+func TestUploadResult_Shape(t *testing.T) {
+	r := UploadResult{
+		Total:   10,
+		Success: 8,
+		Failures: []UploadFailure{
+			{Path: "a.png", Error: "boom"},
+			{Path: "b.png", Error: "timeout"},
+		},
+	}
+	if r.GetTotal() != 10 {
+		t.Errorf("GetTotal = %d", r.GetTotal())
+	}
+	if len(r.GetFailures()) != 2 {
+		t.Errorf("GetFailures len = %d", len(r.GetFailures()))
+	}
+}


### PR DESCRIPTION
## Summary

修复 #44：\`UploadMediaForDeploy\` 对单文件失败只 log 就 \`return nil\`，上层 \`DeployService\` 把 CDN 错误降级为 warning。结果：100 张图有 50 张上传失败时，用户看到 toast 是"同步成功"，线上站点 50 张图全 404，用户无感知。

## 修复方案

### \`cdn_upload_service.go\`

- \`UploadMediaForDeploy\` 改签名返回 \`(UploadResult, error)\`
  - \`UploadResult = { Total, Success, Failures: []UploadFailure }\`
  - \`UploadFailure = { Path, Error }\`
  - error 仅用于"整体失败"（读配置失败等），单文件失败不再影响 error
- errgroup 保留"尽量完成"语义：单文件失败不终止整组，而是收集到 \`failures\`
- 日志先汇总"成功 X / 总数 Y / 失败 Z"，再列前 5 条失败详情，避免大批量失败撑爆日志

### \`deploy_service.go\`

- 拿到 \`UploadResult\` 后走 \`cdnFailureAbortReason\` 阈值判断：
  - 同时满足"比例 ≥ 10%"AND"绝对数 ≥ 5"才中止
  - 小图库（≤ 40 张）下的 1~2 个误差不触发，避免被锁死
  - 阈值被 8 个单测覆盖所有边界

## Test plan

- [x] 8 个新增单测：\`no_files\` / \`all_success\` / \`few_failures_below_cap\` / \`high_total_low_ratio\` / \`ratio_ok_abs_low\` / \`ratio_and_abs_over\` / \`half_fail\` + shape test
- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：故意用只读 token 做 CDN，上传一批图后观察 deploy 是否按预期中止并给出失败列表

## 未纳入本 PR

- 前端"失败列表展开 + 复制 + 仅重试失败项"UI —— backend 已通过 \`UploadResult.Failures\` 提供完整数据，可在独立 frontend PR 消费
- 阈值配置化（目前硬编码 10% + 5）—— 如需按站点调整可后续加入 \`CdnSetting\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)