### PR TITLE
fix(deploy): Git 部署拒绝 force push 到 main/master（除非显式开启）(#41)

### DIFF
--- a/backend/internal/deploy/git_deployer.go
+++ b/backend/internal/deploy/git_deployer.go
@@ -23,6 +23,36 @@ func NewGitProvider() *GitProvider {
 	return &GitProvider{}
 }
 
+// destructiveBranches 是"一旦被 force push 覆盖会造成严重后果"的分支名集合。
+// 对应 issue #41：用户把 branch 填成 main/master 会让整条主线变成站点产物，
+// 除非仓库本身就是 user page（<username>.github.io）——那种情形下 main
+// 本来就是部署分支。
+var destructiveBranches = map[string]bool{
+	"main":    true,
+	"master":  true,
+	"develop": true,
+	"release": true,
+}
+
+// isUserPageRepo 判断 repo 路径是否形如 <user>/<user>.github.io（GitHub 用户页）
+// 或 <user>/<user>.gitee.io（Gitee 用户页）。这类仓库的 main 本就是部署分支，
+// 部署到 main 不是误操作。
+func isUserPageRepo(repoPath string) bool {
+	parts := strings.Split(strings.TrimSuffix(repoPath, ".git"), "/")
+	// 取最后两段做匹配，忽略可能的 github.com/ 前缀
+	if len(parts) < 2 {
+		return false
+	}
+	owner := parts[len(parts)-2]
+	name := parts[len(parts)-1]
+	if owner == "" || name == "" {
+		return false
+	}
+	return name == owner+".github.io" ||
+		name == owner+".gitee.io" ||
+		name == owner+".coding.me"
+}
+
 func (p *GitProvider) Deploy(ctx context.Context, outputDir string, setting *domain.Setting, logger LogFunc) error {
 	logger("Preparing git repository...")
 
@@ -159,6 +189,20 @@ func (p *GitProvider) Deploy(ctx context.Context, outputDir string, setting *dom
 	branch := setting.Branch()
 	if branch == "" {
 		branch = "gh-pages"
+	}
+
+	// 分支安全检查（issue #41）：force push 到 main / master / develop / release 会
+	// 抹掉远端历史，典型的误配置是用户把部署分支填成了 main 而仓库不是 user page。
+	// 用户可以在 setting 里把 gitForceOverwrite 开关打开来显式放行，前端 UI 对此
+	// 应给出红色警告。
+	if destructiveBranches[strings.ToLower(branch)] && !isUserPageRepo(repoUrl) && !setting.GitForceOverwrite() {
+		return fmt.Errorf(
+			"拒绝 force push 到「%s」分支：这会覆盖远端已有历史。\n"+
+				"  • 部署分支建议用 gh-pages / pages / site 等独立分支\n"+
+				"  • 若仓库是 %s.github.io 形式的用户/组织站点，请把仓库名补全\n"+
+				"  • 若确实需要强制覆盖，请在平台设置里开启\"强制覆盖目标分支\"选项",
+			branch, setting.Username(),
+		)
 	}
 
 	// 获取当前的本地分支（通常是 master 或 main）

--- a/backend/internal/deploy/git_safety_test.go
+++ b/backend/internal/deploy/git_safety_test.go
@@ -1,0 +1,44 @@
+package deploy
+
+import "testing"
+
+func TestIsUserPageRepo(t *testing.T) {
+	tests := []struct {
+		repo string
+		want bool
+	}{
+		{"alice/alice.github.io", true},
+		{"alice/alice.gitee.io", true},
+		{"alice/alice.coding.me", true},
+		{"alice/my-blog", false},
+		{"alice/gridea-site", false},
+		// 带仓库主机前缀的完整路径
+		{"github.com/alice/alice.github.io", true},
+		{"github.com/alice/my-blog", false},
+		{"github.com/alice/alice.github.io.git", true},
+		// 边界
+		{"", false},
+		{"alice", false},
+		{"/", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.repo, func(t *testing.T) {
+			if got := isUserPageRepo(tt.repo); got != tt.want {
+				t.Errorf("isUserPageRepo(%q) = %v, want %v", tt.repo, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDestructiveBranchesSet(t *testing.T) {
+	for _, name := range []string{"main", "master", "develop", "release"} {
+		if !destructiveBranches[name] {
+			t.Errorf("expected %q to be in destructive set", name)
+		}
+	}
+	for _, name := range []string{"gh-pages", "pages", "deploy"} {
+		if destructiveBranches[name] {
+			t.Errorf("%q should not be destructive", name)
+		}
+	}
+}

--- a/backend/internal/domain/git_force_overwrite_test.go
+++ b/backend/internal/domain/git_force_overwrite_test.go
@@ -1,0 +1,32 @@
+package domain
+
+import "testing"
+
+func TestGitForceOverwrite(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform string
+		cfg      map[string]any
+		want     bool
+	}{
+		{"missing_platform", "github", nil, false},
+		{"empty_cfg", "github", map[string]any{}, false},
+		{"bool_true", "github", map[string]any{"gitForceOverwrite": true}, true},
+		{"bool_false", "github", map[string]any{"gitForceOverwrite": false}, false},
+		{"string_true", "github", map[string]any{"gitForceOverwrite": "true"}, true},
+		{"string_1", "github", map[string]any{"gitForceOverwrite": "1"}, true},
+		{"string_false", "github", map[string]any{"gitForceOverwrite": "false"}, false},
+		{"unrelated_type", "github", map[string]any{"gitForceOverwrite": 42}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Setting{Platform: tt.platform}
+			if tt.cfg != nil {
+				s.PlatformConfigs = map[string]map[string]any{tt.platform: tt.cfg}
+			}
+			if got := s.GitForceOverwrite(); got != tt.want {
+				t.Errorf("GitForceOverwrite() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/domain/setting.go
+++ b/backend/internal/domain/setting.go
@@ -83,9 +83,9 @@ func (s *Setting) InjectCredentials(credentials map[string]string) {
 
 // platformFieldOrder 定义各平台配置项的输出顺序，与前端表单顺序一致
 var platformFieldOrder = map[string][]string{
-	"github":  {"domain", "repository", "branch", "username", "email", "tokenUsername", "token", "cname"},
-	"gitee":   {"domain", "repository", "branch", "username", "email", "tokenUsername", "token", "cname"},
-	"coding":  {"domain", "repository", "branch", "username", "email", "tokenUsername", "token", "cname"},
+	"github":  {"domain", "repository", "branch", "username", "email", "tokenUsername", "token", "cname", "gitForceOverwrite"},
+	"gitee":   {"domain", "repository", "branch", "username", "email", "tokenUsername", "token", "cname", "gitForceOverwrite"},
+	"coding":  {"domain", "repository", "branch", "username", "email", "tokenUsername", "token", "cname", "gitForceOverwrite"},
 	"netlify": {"domain", "netlifySiteId", "netlifyAccessToken"},
 	"vercel":  {"domain", "repository", "token", "cname"},
 	"sftp":    {"domain", "transferProtocol", "server", "port", "username", "password", "privateKey", "remotePath"},
@@ -275,6 +275,26 @@ func (s *Setting) RemotePath() string { return s.Get("remotePath") }
 
 // TransferProtocol 当前平台的传输协议（sftp 或 ftp）
 func (s *Setting) TransferProtocol() string { return s.Get("transferProtocol") }
+
+// GitForceOverwrite 是否允许 force push 到 main / master 等主分支。
+// 默认 false；仅在用户明确知悉"远端历史会被覆盖"的情况下开启。
+// 见 issue #41：防止误把 branch 填成 main 导致主线被站点产物替换。
+func (s *Setting) GitForceOverwrite() bool {
+	if s.PlatformConfigs == nil {
+		return false
+	}
+	cfg, ok := s.PlatformConfigs[s.Platform]
+	if !ok {
+		return false
+	}
+	switch v := cfg["gitForceOverwrite"].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "1"
+	}
+	return false
+}
 
 // Validate 校验配置数据
 func (s *Setting) Validate() error {

--- a/frontend/src/views/settings/components/BasicSetting.vue
+++ b/frontend/src/views/settings/components/BasicSetting.vue
@@ -303,6 +303,13 @@
             <FormField label="CNAME">
               <Input v-model="drawerForm.cname" placeholder="mydomain.com" />
             </FormField>
+            <!-- Git 强制覆盖目标分支（高危选项，#41） -->
+            <FormField label="强制覆盖目标分支">
+              <Switch :checked="!!drawerForm.gitForceOverwrite" @update:checked="drawerForm.gitForceOverwrite = $event" />
+              <template #hint>
+                <span class="text-red-500">⚠️ 开启后会 force push 到目标分支，覆盖远端已有提交。默认关闭以防误配置（如把 branch 填成 main）</span>
+              </template>
+            </FormField>
           </template>
 
           <!-- ─ Netlify ─ -->
@@ -551,6 +558,7 @@ const drawerForm = reactive<Record<string, any>>({
   token: '',
   cname: '',
   transferProtocol: 'sftp',
+  gitForceOverwrite: false,
   port: '',
   server: '',
   password: '',
@@ -925,9 +933,9 @@ function buildSettingForPlatform(platformId: string) {
   const domain = drawerForm.domain ? `https://${drawerForm.domain.replace(/\/+$/, '')}` : ''
 
   const platformFieldMap: Record<string, string[]> = {
-    github: ['domain', 'repository', 'branch', 'username', 'email', 'tokenUsername', 'token', 'cname'],
-    gitee: ['domain', 'repository', 'branch', 'username', 'email', 'tokenUsername', 'token', 'cname'],
-    coding: ['domain', 'repository', 'branch', 'username', 'email', 'tokenUsername', 'token', 'cname'],
+    github: ['domain', 'repository', 'branch', 'username', 'email', 'tokenUsername', 'token', 'cname', 'gitForceOverwrite'],
+    gitee: ['domain', 'repository', 'branch', 'username', 'email', 'tokenUsername', 'token', 'cname', 'gitForceOverwrite'],
+    coding: ['domain', 'repository', 'branch', 'username', 'email', 'tokenUsername', 'token', 'cname', 'gitForceOverwrite'],
     netlify: ['domain', 'netlifySiteId', 'netlifyAccessToken'],
     vercel: ['domain', 'repository', 'token', 'cname'],
     sftp: ['domain', 'transferProtocol', 'server', 'port', 'username', 'password', 'privateKey', 'remotePath'],
@@ -938,6 +946,8 @@ function buildSettingForPlatform(platformId: string) {
   for (const f of fields) {
     if (f === 'domain') {
       cfg.domain = domain
+    } else if (f === 'gitForceOverwrite') {
+      cfg[f] = !!drawerForm[f]
     } else {
       cfg[f] = drawerForm[f] || ''
     }


### PR DESCRIPTION
## Summary

修复 #41（P0 可靠性）：\`git_deployer\` 每次都 \`+refs/heads/xxx\` force push。若用户把 branch 字段填成 main / master 而仓库又不是 user page（\`<user>.github.io\`），一次发布就会把主线覆盖成站点产物，远端其他协作者的提交全被静默抹掉。

## 修复方案（封最常见的误配置陷阱）

- \`destructiveBranches\`：main / master / develop / release
- \`isUserPageRepo\`：识别 \`<user>.github.io\` / \`.gitee.io\` / \`.coding.me\`（这类仓库 main 本就是部署分支，不算误操作）
- 部署 gate：目标分支在 destructive 集合 AND 不是 user page AND \`setting.gitForceOverwrite\` 未开启 → 直接拒绝，给出可执行的修复建议
- 新增 \`gitForceOverwrite\` 布尔 setting + 前端红字警告 Switch，让高级用户可以显式放行

## 未纳入本 PR（issue 的完整方案是更大重构）

1. 渲染目录与部署仓库目录**物理分离**（\`.deploy-repo/\`）
2. \`fetch + merge\` 替代 force push 的真·安全语义（基于远端 HEAD 构建新 commit）
3. 远端有冲突时前端弹窗 \"合并 / 强制 / 取消\"

这些需要动很多层（git_deployer / deploy_service / engine 的 output 解耦），本 PR 先把最高频的一个陷阱堵住；全量安全推送独立 issue 推进。

## Test plan

- [x] 11 个 \`isUserPageRepo\` 子 case（.github.io / .gitee.io / .coding.me / 带 github.com 前缀 / .git 后缀 / 空 / 单段）
- [x] \`destructiveBranches\` 集合：4 个 IN + 3 个 NOT IN
- [x] 8 个 \`GitForceOverwrite\` 解析 case（bool / 字符串 / 非法类型）
- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：
  - 把 github 的 branch 填成 \`main\` 试发布 → 应收到清晰中文拒绝 + 建议
  - 打开"强制覆盖"Switch 后再发布 → 正常 force push
  - 部署到 \`<user>.github.io\` 仓库的 main → 默认就能通过（本来就该）

🤖 Generated with [Claude Code](https://claude.com/claude-code)