### PR TITLE
feat(deploy): 部署流程可取消 (#42)

### DIFF
--- a/backend/internal/facade/deploy_facade.go
+++ b/backend/internal/facade/deploy_facade.go
@@ -21,3 +21,14 @@ func (f *DeployFacade) DeployToGit() error {
 	}
 	return f.internal.DeployToRemote(ctx)
 }
+
+// CancelDeploy 对外暴露给前端调用；正在进行的部署会被 ctx 取消（见 #42）。
+// 空闲时 no-op。
+func (f *DeployFacade) CancelDeploy() {
+	f.internal.CancelDeploy()
+}
+
+// IsDeploying 返回当前是否有部署在进行，前端按钮状态同步时使用。
+func (f *DeployFacade) IsDeploying() bool {
+	return f.internal.IsDeploying()
+}

--- a/backend/internal/service/deploy_service.go
+++ b/backend/internal/service/deploy_service.go
@@ -21,6 +21,7 @@ type DeployService struct {
 	appDir           string
 	mu               sync.Mutex
 	isDeploying      bool
+	activeCancel     context.CancelFunc // 当前部署的取消函数；空闲时为 nil（issue #42）
 }
 
 func NewDeployService(settingRepo domain.SettingRepository, appDir string) *DeployService {
@@ -46,19 +47,27 @@ func (s *DeployService) SetCdnUploadService(cdnUpload *CdnUploadService) {
 }
 
 func (s *DeployService) DeployToRemote(ctx context.Context) error {
+	// 为本次部署创建可取消的 ctx，暴露 cancel 给 CancelDeploy 调用。
+	deployCtx, cancel := context.WithCancel(ctx)
+
 	s.mu.Lock()
 	if s.isDeploying {
 		s.mu.Unlock()
+		cancel()
 		return fmt.Errorf(domain.ErrDeployInProgress)
 	}
 	s.isDeploying = true
+	s.activeCancel = cancel
 	s.mu.Unlock()
+	ctx = deployCtx
 
 	// Ensure we reset the flag when done
 	defer func() {
 		s.mu.Lock()
 		s.isDeploying = false
+		s.activeCancel = nil
 		s.mu.Unlock()
+		cancel()
 	}()
 
 	s.log(ctx, "Starting deployment check...")
@@ -141,6 +150,25 @@ func (s *DeployService) DeployToRemote(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// CancelDeploy 中断当前正在进行的部署。
+// 若当前空闲则 no-op，不返回错误。取消后 DeployToRemote 会收到 ctx.Canceled
+// 并尽可能快地退出（各 provider 内部的 HTTP / walk 循环都要尊重 ctx）。
+func (s *DeployService) CancelDeploy() {
+	s.mu.Lock()
+	cancel := s.activeCancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// IsDeploying 返回当前是否有部署在进行中，供前端按钮状态同步使用。
+func (s *DeployService) IsDeploying() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.isDeploying
 }
 
 // log sends a message to the frontend safely

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -59,13 +59,17 @@ variant="outline"
           {{ t('nav.preview') }}
         </Button>
 
+        <!-- 发布 / 取消按钮（#42）：部署中点击切换为取消；不再需要 disabled -->
         <Button
 variant="default"
-          class="w-36 h-8 text-xs justify-center rounded-full bg-primary text-background hover:bg-primary/90 cursor-pointer"
-          :disabled="publishLoading" @click="publish">
-          <template v-if="publishLoading">
+          class="w-36 h-8 text-xs justify-center rounded-full cursor-pointer"
+          :class="publishLoading
+            ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+            : 'bg-primary text-background hover:bg-primary/90'"
+          @click="publishLoading ? cancelPublish() : publish()">
+          <template v-if="publishLoading && !cancelling">
             <svg
-class="animate-spin h-4 w-4 text-primary-foreground"
+class="animate-spin h-4 w-4 text-destructive-foreground"
               xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
               <path
@@ -73,6 +77,10 @@ class="opacity-75" fill="currentColor"
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
               </path>
             </svg>
+            <span class="ml-2">取消发布</span>
+          </template>
+          <template v-else-if="cancelling">
+            <span class="text-xs">取消中...</span>
           </template>
           <template v-else>
             <RocketLaunchIcon class="size-3 mr-2" />
@@ -290,7 +298,7 @@ import { useSiteStore } from '@/stores/site'
 import AppSystem from '@/views/preferences/index.vue'
 import { Button } from '@/components/ui/button'
 import { EventsEmit, EventsOn, BrowserOpenURL } from '@/wailsjs/runtime'
-import { DeployToGit } from '@/wailsjs/go/facade/DeployFacade'
+import { DeployToGit, CancelDeploy } from '@/wailsjs/go/facade/DeployFacade'
 import {
   CheckUpdate,
   StartDownload,
@@ -359,6 +367,7 @@ const updateContent = ref('')
 const logModalVisible = ref(false)
 const sidebarVisible = ref(true)
 const log = ref<any>({})
+const cancelling = ref(false)
 
 const currentRouter = computed(() => route.path)
 
@@ -441,13 +450,28 @@ const publish = async () => {
     })
   } catch (error: any) {
     console.error('Deploy error:', error)
-    log.value = {
-      type: t('dashboard.syncError1'),
-      message: error.message || String(error)
+    const msg = error?.message || String(error)
+    // ctx 被取消：不当作"失败"弹错误，给"已取消"toast
+    if (/canceled|cancelled|取消/i.test(msg)) {
+      EventsEmit('app:toast', { message: '已取消发布', type: 'info', duration: 2000 })
+    } else {
+      log.value = { type: t('dashboard.syncError1'), message: msg }
+      logModalVisible.value = true
     }
-    logModalVisible.value = true
   } finally {
     publishLoading.value = false
+    cancelling.value = false
+  }
+}
+
+const cancelPublish = async () => {
+  if (!publishLoading.value || cancelling.value) return
+  cancelling.value = true
+  try {
+    await CancelDeploy()
+  } catch (e) {
+    console.error('CancelDeploy error:', e)
+    cancelling.value = false
   }
 }
 


### PR DESCRIPTION
## Summary

修复 #42：\`DeployFacade.DeployToGit\` 原本使用全局 \`WailsContext\`（永远不 Done），没有可取消的子 ctx。用户发现 token / 仓库配错后只能等整次部署跑完或强杀进程。

## 修复方案

### 后端

- \`DeployService\` 新增 \`activeCancel context.CancelFunc\` 字段
- \`DeployToRemote\` 入口 \`WithCancel\` 派生子 ctx，把 cancel 存到 \`activeCancel\`；defer 时清理并调用
- 新增 \`CancelDeploy()\` / \`IsDeploying()\` 公开方法
- \`DeployFacade\` 暴露上述两个方法给前端（Wails 绑定）

### 前端

- \`MainLayout.vue\` 发布按钮改造：
  - 空闲 → 蓝色"发布"
  - 发布中 → **红色"取消发布"**（替代原来的 disabled loading spinner）
  - 点击取消 → 按钮文案切换为"取消中..."直到后端返回
  - \`publish()\` 的 catch 块对 ctx 取消错误专用 \`toast('已取消发布')\`，不弹"部署失败"错误窗

### wailsjs 绑定

目录在 \`.gitignore\` 中，由 \`wails build\` / \`wails dev\` 根据 facade 方法签名自动生成，本 PR 不手工提交。

## 与相邻 PR 的关系

- #49（PR #87）的"总超时 30 分钟"已经给了兜底时间；本 PR 让用户可以随时手动中断
- Provider 内部对 ctx 已有部分覆盖（HTTP 请求 / walk 开头 select），两者叠加后绝大多数阻塞点都能被及时中断
- SFTP/FTP 的 \`io.Copy\` 粒度 ctx 覆盖（在 64KB 循环里 select）留作 follow-up —— 但该场景下 ctx 取消会触发 \`defer conn.Close()\`，连接关闭也会打断 io.Copy

## Test plan

- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：
  - 发起大站 SFTP 部署 → 点"取消发布" → 应立即或在几秒内返回"已取消发布"
  - Vercel / Netlify 上传中途取消 → HTTP 请求应被 ctx 打断
  - 取消后立刻重新发布 → 应能正常进入新一轮（\`isDeploying\` 已释放）

🤖 Generated with [Claude Code](https://claude.com/claude-code)