### PR TITLE
fix(deploy): HTTP 上传指数退避重试 (#46)

### DIFF
--- a/backend/internal/deploy/httpretry.go
+++ b/backend/internal/deploy/httpretry.go
@@ -1,0 +1,178 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HTTPRetryPolicy 描述一次"带重试的 HTTP 调用"的策略。零值意味着"不重试"。
+//
+// buildReq 是请求工厂（每次重试都重新构造），文件上传场景必须在工厂里 os.Open 新句柄；
+// 不能提前读入 body —— 失败后的 request body 已经被消费。
+type HTTPRetryPolicy struct {
+	MaxAttempts     int           // 总尝试次数，默认 1
+	BaseDelay       time.Duration // 首次退避基准，默认 500ms
+	MaxDelay        time.Duration // 单次退避上限，默认 30s
+	RetryableStatus []int         // 可重试的 HTTP 状态码；为空时使用默认白名单
+}
+
+// defaultRetryableStatus 对幂等写（PUT / DELETE）和 GET 都是可重试的典型集合。
+// 408 / 429 / 5xx 意味着"服务端暂时不可用或要求稍后重试"。
+var defaultRetryableStatus = []int{
+	http.StatusRequestTimeout,     // 408
+	http.StatusTooManyRequests,    // 429
+	http.StatusInternalServerError,
+	http.StatusBadGateway,
+	http.StatusServiceUnavailable,
+	http.StatusGatewayTimeout,
+}
+
+// DoHTTPWithRetry 执行一次带重试的 HTTP 调用。
+//
+//   - 每次尝试前调用 buildReq 构造新的 *http.Request（对文件 body 尤其关键）
+//   - 仅对"网络错误" 或 "白名单内的 HTTP 状态码"进行重试
+//   - 退避：指数 + 随机 jitter，429 响应优先使用 Retry-After 头
+//   - 任何时刻 ctx.Done() 返回 ctx.Err() 并不再重试
+//   - onRetry 非 nil 时在即将等待重试时调用（供上层打印"第 N 次重试中..."）
+//
+// 成功（2xx 或不可重试的 4xx）返回 *http.Response；调用方必须负责 Close Body。
+func DoHTTPWithRetry(
+	ctx context.Context,
+	client *http.Client,
+	buildReq func() (*http.Request, error),
+	policy HTTPRetryPolicy,
+	onRetry func(attempt int, waitFor time.Duration, reason string),
+) (*http.Response, error) {
+	if policy.MaxAttempts < 1 {
+		policy.MaxAttempts = 1
+	}
+	if policy.BaseDelay <= 0 {
+		policy.BaseDelay = 500 * time.Millisecond
+	}
+	if policy.MaxDelay <= 0 {
+		policy.MaxDelay = 30 * time.Second
+	}
+	retryable := policy.RetryableStatus
+	if len(retryable) == 0 {
+		retryable = defaultRetryableStatus
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		req, err := buildReq()
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+
+		if err == nil && !isRetryableStatus(resp.StatusCode, retryable) {
+			return resp, nil
+		}
+
+		// 失败或非 2xx 可重试：清理当前响应，准备下一轮
+		var reason string
+		var retryAfter time.Duration
+		if err != nil {
+			if !isRetryableErr(err) {
+				return nil, err
+			}
+			reason = fmt.Sprintf("网络错误：%v", err)
+			lastErr = err
+		} else {
+			retryAfter = parseRetryAfter(resp.Header.Get("Retry-After"))
+			reason = fmt.Sprintf("HTTP %d", resp.StatusCode)
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+			resp.Body.Close()
+		}
+
+		if attempt >= policy.MaxAttempts {
+			return nil, fmt.Errorf("重试 %d 次仍失败: %w", policy.MaxAttempts, lastErr)
+		}
+
+		wait := retryAfter
+		if wait <= 0 {
+			wait = expoBackoff(attempt, policy)
+		}
+		if onRetry != nil {
+			onRetry(attempt, wait, reason)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return nil, fmt.Errorf("重试 %d 次仍失败: %w", policy.MaxAttempts, lastErr)
+}
+
+func isRetryableStatus(code int, allow []int) bool {
+	for _, c := range allow {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}
+
+// isRetryableErr 粗略判定"值得重试的网络错误"。
+// - net.Error.Timeout() / Temporary()
+// - connection reset / broken pipe / no such host / EOF 等字符串兜底
+func isRetryableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "EOF")
+}
+
+// parseRetryAfter 解析 429 响应的 Retry-After 头。
+// 支持"秒数"和 HTTP-date 两种格式；无法解析时返回 0（由调用方退化到指数退避）。
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// expoBackoff 返回第 attempt 次重试的等待时长：BaseDelay * 2^(attempt-1) + jitter，
+// 不超过 MaxDelay。attempt 从 1 起计。
+func expoBackoff(attempt int, policy HTTPRetryPolicy) time.Duration {
+	base := policy.BaseDelay << (attempt - 1)
+	if base > policy.MaxDelay || base < policy.BaseDelay /* 防溢出 */ {
+		base = policy.MaxDelay
+	}
+	jitter := time.Duration(rand.Int64N(int64(base / 4)))
+	wait := base + jitter
+	if wait > policy.MaxDelay {
+		wait = policy.MaxDelay
+	}
+	return wait
+}

--- a/backend/internal/deploy/httpretry_test.go
+++ b/backend/internal/deploy/httpretry_test.go
@@ -1,0 +1,158 @@
+package deploy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func mkGetReq(ctx context.Context, url string) func() (*http.Request, error) {
+	return func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	}
+}
+
+func TestDoHTTPWithRetry_RetriesOn5xxAndSucceeds(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := DoHTTPWithRetry(ctx, &http.Client{Timeout: 2 * time.Second},
+		mkGetReq(ctx, srv.URL), HTTPRetryPolicy{MaxAttempts: 3, BaseDelay: 10 * time.Millisecond}, nil)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected 3 hits, got %d", got)
+	}
+}
+
+func TestDoHTTPWithRetry_4xxNotRetried(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := DoHTTPWithRetry(ctx, &http.Client{Timeout: 2 * time.Second},
+		mkGetReq(ctx, srv.URL), HTTPRetryPolicy{MaxAttempts: 3, BaseDelay: 5 * time.Millisecond}, nil)
+	if err != nil {
+		t.Fatalf("4xx 不应返回 error，应 return resp，实际 %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("4xx 不应触发重试，实际 %d hits", got)
+	}
+}
+
+func TestDoHTTPWithRetry_ExhaustedReturnsError(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := DoHTTPWithRetry(ctx, &http.Client{Timeout: 2 * time.Second},
+		mkGetReq(ctx, srv.URL), HTTPRetryPolicy{MaxAttempts: 3, BaseDelay: 5 * time.Millisecond}, nil)
+	if err == nil {
+		t.Fatal("expected exhaustion error")
+	}
+	if !strings.Contains(err.Error(), "重试 3 次") {
+		t.Errorf("expected '重试 3 次' in err, got %v", err)
+	}
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestDoHTTPWithRetry_RespectsRetryAfter(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := DoHTTPWithRetry(ctx, &http.Client{Timeout: 2 * time.Second},
+		mkGetReq(ctx, srv.URL),
+		// BaseDelay 刻意很小；如果 Retry-After 生效，总耗时应至少 1s
+		HTTPRetryPolicy{MaxAttempts: 3, BaseDelay: 10 * time.Millisecond}, nil)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("expected to wait at least ~1s for Retry-After, got %v", elapsed)
+	}
+}
+
+func TestDoHTTPWithRetry_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := DoHTTPWithRetry(ctx, &http.Client{Timeout: 2 * time.Second},
+		mkGetReq(ctx, srv.URL),
+		HTTPRetryPolicy{MaxAttempts: 5, BaseDelay: 100 * time.Millisecond}, nil)
+	if err == nil {
+		t.Fatal("expected ctx cancellation error")
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	if d := parseRetryAfter("3"); d != 3*time.Second {
+		t.Errorf("seconds parse: got %v", d)
+	}
+	if d := parseRetryAfter(""); d != 0 {
+		t.Errorf("empty: got %v", d)
+	}
+	if d := parseRetryAfter("invalid"); d != 0 {
+		t.Errorf("invalid: got %v", d)
+	}
+}

--- a/backend/internal/deploy/netlify_deployer.go
+++ b/backend/internal/deploy/netlify_deployer.go
@@ -242,24 +242,26 @@ func (p *NetlifyProvider) uploadFiles(ctx context.Context, outputDir, deployId s
 	return eg.Wait()
 }
 
-// uploadSingleFile 上传单个文件到 Netlify
+// uploadSingleFile 上传单个文件到 Netlify。
+// PUT 幂等 + Netlify 服务端通过 deployId 锁定目标，5xx/429/网络错误重试安全（见 #46）。
 func (p *NetlifyProvider) uploadSingleFile(ctx context.Context, deployId, localPath, remotePath, token string) error {
-	file, err := os.Open(localPath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
 	apiURL := fmt.Sprintf("%s/deploys/%s/files%s", netlifyAPIBase, deployId, remotePath)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, apiURL, file)
-	if err != nil {
-		return err
+	buildReq := func() (*http.Request, error) {
+		file, err := os.Open(localPath)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, apiURL, file)
+		if err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("Authorization", "Bearer "+token)
+		return req, nil
 	}
 
-	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := p.client.Do(req)
+	resp, err := DoHTTPWithRetry(ctx, p.client, buildReq, HTTPRetryPolicy{MaxAttempts: 3}, nil)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/deploy/vercel_deployer.go
+++ b/backend/internal/deploy/vercel_deployer.go
@@ -219,24 +219,28 @@ func (p *VercelProvider) uploadFiles(ctx context.Context, outputDir string, file
 	return eg.Wait()
 }
 
-// uploadSingleFile 上传单个文件到 Vercel
+// uploadSingleFile 上传单个文件到 Vercel。
+// 带有 x-vercel-digest 的 POST 是内容寻址的幂等写入（见 #46），5xx/429/网络
+// 错误可安全重试，因此这里走 DoHTTPWithRetry 而非直接 client.Do。
 func (p *VercelProvider) uploadSingleFile(ctx context.Context, filePath, sha string, size int64, token string) error {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return err
+	buildReq := func() (*http.Request, error) {
+		// 每次重试重新 Open 文件；body 在失败后已被 http.Transport 消费，不能复用
+		file, err := os.Open(filePath)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.vercel.com/v2/files", file)
+		if err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("x-vercel-digest", sha)
+		req.ContentLength = size
+		return req, nil
 	}
-	defer file.Close()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.vercel.com/v2/files", file)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("x-vercel-digest", sha)
-	req.ContentLength = size
-
-	resp, err := p.client.Do(req)
+	resp, err := DoHTTPWithRetry(ctx, p.client, buildReq, HTTPRetryPolicy{MaxAttempts: 3}, nil)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/service/cdn_upload_service.go
+++ b/backend/internal/service/cdn_upload_service.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"gridea-pro/backend/internal/deploy"
 	"gridea-pro/backend/internal/domain"
 
 	gonanoid "github.com/matoous/go-nanoid/v2"
@@ -174,15 +175,20 @@ func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.Cd
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s",
 		setting.GithubUser, setting.GithubRepo, remotePath)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, strings.NewReader(string(bodyJSON)))
-	if err != nil {
-		return fmt.Errorf("创建请求失败: %w", err)
+	// GitHub Contents API 的 PUT 是内容寻址（带 sha），幂等可安全重试（#46）。
+	// 5xx / 429 / 瞬时网络错误自动退避 3 次；429 会尊重 Retry-After 头。
+	buildReq := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, strings.NewReader(string(bodyJSON)))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+setting.GithubToken)
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
 	}
-	req.Header.Set("Authorization", "Bearer "+setting.GithubToken)
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := s.httpClient(ctx).Do(req)
+	resp, err := deploy.DoHTTPWithRetry(ctx, s.httpClient(ctx), buildReq, deploy.HTTPRetryPolicy{MaxAttempts: 3}, nil)
 	if err != nil {
 		return fmt.Errorf("上传失败: %w", err)
 	}


### PR DESCRIPTION
## Summary

修复 #46：Vercel / Netlify / CDN 的所有 HTTP 上传原本"失败就 return err"，errgroup 一拿到错误就取消其它任务，整次部署失败。移动热点切 WiFi / 5xx 限流 / 429 限速 / TLS handshake 瞬时失败等场景下，用户会频繁看到"一次成功、一次失败"。

## 修复方案

### 新增通用 retry helper

\`backend/internal/deploy/httpretry.go\`：

- **\`buildReq\` 工厂**每轮重建 request —— 解决"body 是 \`io.Reader\`，失败后已被 \`http.Transport\` 消费无法复用"的经典坑
- 默认可重试状态码 **408 / 429 / 500 / 502 / 503 / 504**
- 可重试 \`net.Error\`（Timeout / connection reset / no such host / EOF）
- **指数退避 + 1/4 jitter**，单次最多 30s；429 响应**优先使用 \`Retry-After\`** 头（秒数 / HTTP-date 都支持）
- 响应 \`ctx.Done\` 立刻退出，不再等待
- \`onRetry\` 回调供上层打印"第 N 次重试..."（本 PR 暂未连接，留给 #43 DeployEvent）

### 接入点

| 位置 | 方法 | 幂等性 |
|---|---|---|
| \`VercelProvider.uploadSingleFile\` | POST + \`x-vercel-digest\` | 内容寻址，幂等 ✅ |
| \`NetlifyProvider.uploadSingleFile\` | PUT to \`/deploys/{id}/files/{path}\` | 路径+deployId 锁定，幂等 ✅ |
| \`CdnUploadService.uploadToGitHub\` | PUT + GitHub Contents API \`sha\` | sha 幂等 ✅ |

所有接入点都是 **MaxAttempts=3** + 默认策略。

## 没接入的位置（已在 commit 注释里说明理由）

- \`createDeployment\` (Vercel POST) / \`createDeploy\` (Netlify POST) —— 创建 deploy entity 并非纯幂等，重试可能产生多个 deploy。需要 Idempotency-Key 配合，独立 issue 评估
- \`getGithubFileSHA\` (GET) —— 现行错误路径就是"文件不存在"（业务语义），接入 retry 反而把瞬时错误拖成 3x 延迟

## Test plan

- [x] 6 个单测：5xx 三轮恢复 / 4xx 不重试 / 重试耗尽带清晰错误 / \`Retry-After: 1\` 被尊重（总耗时 ≥ 1s） / ctx 取消立即停 / \`parseRetryAfter\` 多格式
- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：
  - 使用 \`nlc\` / \`tc qdisc\` 模拟 30% 丢包，发起 Vercel / Netlify 大站部署
  - 预期：部分单文件上传会看到重试，但整体仍能完成

🤖 Generated with [Claude Code](https://claude.com/claude-code)