### PR TITLE
fix(cdn): 本地 CDN manifest 缓存，重复部署 0 API 调用 (#45)

### DIFF
--- a/backend/internal/service/cdn_manifest.go
+++ b/backend/internal/service/cdn_manifest.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// cdnManifest 记录一份"远端路径 → 本地 git blob SHA"的映射。
+// 持久化在 <appDir>/.cdn-manifest.json，用于跨次部署避免重复的 GET+PUT（见 issue #45）。
+//
+// 核心假设：一旦某个 remotePath 在远端上传成功，本地就会记录对应的
+// blob SHA；下次部署时若本地算出同样的 SHA，就可以直接跳过 API 调用，
+// 不需要再向 GitHub 查询远端状态。
+type cdnManifest struct {
+	mu      sync.Mutex
+	Entries map[string]string `json:"entries"` // remotePath → localSHA
+}
+
+// loadCdnManifest 从 appDir 读取 manifest；文件不存在或解析失败时返回空白 manifest。
+func loadCdnManifest(appDir string) *cdnManifest {
+	m := &cdnManifest{Entries: make(map[string]string)}
+	data, err := os.ReadFile(filepath.Join(appDir, ".cdn-manifest.json"))
+	if err != nil {
+		return m
+	}
+	// 忽略解析错误：异常文件当作"空缓存"，迫使所有文件都重新走一遍完整路径。
+	_ = json.Unmarshal(data, m)
+	if m.Entries == nil {
+		m.Entries = make(map[string]string)
+	}
+	return m
+}
+
+// save 将 manifest 写回磁盘；并发安全。
+func (m *cdnManifest) save(appDir string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(appDir, ".cdn-manifest.json"), data, 0o644)
+}
+
+// hit 查询某个远端路径的已知 SHA；未命中返回 ""，false。
+func (m *cdnManifest) hit(remotePath string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sha, ok := m.Entries[remotePath]
+	return sha, ok
+}
+
+// record 写入一次成功上传后的映射。
+func (m *cdnManifest) record(remotePath, sha string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Entries[remotePath] = sha
+}

--- a/backend/internal/service/cdn_manifest_test.go
+++ b/backend/internal/service/cdn_manifest_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCdnManifest_EmptyLoadReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	m := loadCdnManifest(dir)
+	if m == nil {
+		t.Fatal("loadCdnManifest returned nil")
+	}
+	if len(m.Entries) != 0 {
+		t.Errorf("expected empty entries, got %v", m.Entries)
+	}
+}
+
+func TestCdnManifest_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	m := loadCdnManifest(dir)
+	m.record("post-images/a.png", "sha-a")
+	m.record("post-images/b.png", "sha-b")
+	if err := m.save(dir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// 再读一次应该拿到同样的内容
+	m2 := loadCdnManifest(dir)
+	if sha, ok := m2.hit("post-images/a.png"); !ok || sha != "sha-a" {
+		t.Errorf("expected a.png sha-a, got %v %v", sha, ok)
+	}
+	if sha, ok := m2.hit("post-images/b.png"); !ok || sha != "sha-b" {
+		t.Errorf("expected b.png sha-b, got %v %v", sha, ok)
+	}
+	if _, ok := m2.hit("missing.png"); ok {
+		t.Error("expected miss on unknown path")
+	}
+}
+
+func TestCdnManifest_CorruptFileTreatedAsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// 写一个无法解析的 JSON
+	_ = os.WriteFile(filepath.Join(dir, ".cdn-manifest.json"), []byte("{{{not json"), 0o644)
+
+	m := loadCdnManifest(dir)
+	if m == nil {
+		t.Fatal("loadCdnManifest returned nil")
+	}
+	if len(m.Entries) != 0 {
+		t.Errorf("corrupt manifest should fall back to empty, got %v", m.Entries)
+	}
+	// 并且 record / save 仍应工作
+	m.record("x", "y")
+	if err := m.save(dir); err != nil {
+		t.Fatalf("save after corrupt reload: %v", err)
+	}
+}
+
+func TestCdnManifest_RecordUpdatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	m := loadCdnManifest(dir)
+	m.record("a.png", "old-sha")
+	m.record("a.png", "new-sha")
+	sha, ok := m.hit("a.png")
+	if !ok || sha != "new-sha" {
+		t.Errorf("expected new-sha, got %v %v", sha, ok)
+	}
+}

--- a/backend/internal/service/cdn_upload_service.go
+++ b/backend/internal/service/cdn_upload_service.go
@@ -132,8 +132,11 @@ type githubContentsResponse struct {
 	SHA string `json:"sha"`
 }
 
-// uploadToGitHub 通过 GitHub Contents API 上传单个文件
-func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.CdnSetting, localFilePath, remotePath string) error {
+// uploadToGitHub 通过 GitHub Contents API 上传单个文件。
+// manifest 非 nil 时走本地 manifest 缓存（#45）：若 remotePath 在上次成功上传后
+// 仍是同一个 SHA，直接跳过整个 API 往返；否则仍需一次 GET 查远端 SHA 做增量。
+// 成功上传后向 manifest 记录新的 (remotePath → localSHA)。
+func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.CdnSetting, localFilePath, remotePath string, manifest *cdnManifest) error {
 	// 读取本地文件
 	data, err := os.ReadFile(localFilePath)
 	if err != nil {
@@ -148,10 +151,21 @@ func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.Cd
 	// 计算本地文件 SHA（git blob SHA1）
 	localSHA := gitBlobSHA(data)
 
-	// 检查文件是否已存在
+	// 快速路径：本地 manifest 命中且 SHA 未变，直接跳过 API。
+	// 放开这条后大部分"重复部署"场景都不再调用 GitHub API，配额保留给真正的变更。
+	if manifest != nil {
+		if cached, ok := manifest.hit(remotePath); ok && cached == localSHA {
+			return nil
+		}
+	}
+
+	// 慢路径：manifest 未命中或 SHA 变更，还需一次 GET 拿远端 SHA 做增量更新
 	existingSHA, err := s.getGithubFileSHA(ctx, setting, remotePath, branch)
 	if err == nil && existingSHA == localSHA {
-		// 文件内容相同，跳过
+		// 文件内容相同，跳过上传，但补录到 manifest 避免下次再 GET
+		if manifest != nil {
+			manifest.record(remotePath, localSHA)
+		}
 		return nil
 	}
 
@@ -207,6 +221,10 @@ func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.Cd
 		}
 	}
 
+	// 成功：把新 SHA 写入 manifest，后续部署可以直接走快速路径
+	if manifest != nil {
+		manifest.record(remotePath, localSHA)
+	}
 	return nil
 }
 
@@ -286,8 +304,8 @@ func (s *CdnUploadService) TestUpload(ctx context.Context) (string, error) {
 	}
 	remotePath := ResolveSavePath(savePath, "gridea-test.txt")
 
-	// 上传
-	if err := s.uploadToGitHub(ctx, setting, tmpFile.Name(), remotePath); err != nil {
+	// 上传（测试场景不走 manifest 缓存：每次都实际触达 API 以便验证配置）
+	if err := s.uploadToGitHub(ctx, setting, tmpFile.Name(), remotePath, nil); err != nil {
 		return "", err
 	}
 
@@ -306,6 +324,15 @@ func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir stri
 	if !setting.Enabled || setting.GithubToken == "" {
 		return nil
 	}
+
+	// 加载本地 manifest：命中的文件跳过整轮 API 调用（#45）
+	manifest := loadCdnManifest(appDir)
+	defer func() {
+		// 无论成功失败都持久化已有进度，单文件失败不影响其它文件的快路径
+		if err := manifest.save(appDir); err != nil {
+			logger(fmt.Sprintf("警告：写入 CDN manifest 失败（下次将重新全量检查）: %v", err))
+		}
+	}()
 
 	// 需要扫描的目录
 	mediaDirs := []string{"post-images", "images", "media"}
@@ -367,7 +394,7 @@ func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir stri
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			if err := s.uploadToGitHub(gCtx, setting, f.localPath, f.remotePath); err != nil {
+			if err := s.uploadToGitHub(gCtx, setting, f.localPath, f.remotePath, manifest); err != nil {
 				logger(fmt.Sprintf("上传 %s 失败: %v", f.remotePath, err))
 				return nil // 单个文件失败不中断整个上传
 			}


### PR DESCRIPTION
## Summary

修复 #45：\`uploadToGitHub\` 每个文件都 GET + PUT。100 张图 = 200 次 API 调用，GitHub token 限流 5000/h 下一天连续部署 10 次就耗尽。关键点：**绝大多数"重复部署"场景文件根本没变**，根本不需要 GET 查询。

## 修复方案

- 新增 \`cdn_manifest.go\`：\`<appDir>/.cdn-manifest.json\` 持久化 \`{remotePath: localSHA}\` 映射
- \`uploadToGitHub\` 新增 \`*cdnManifest\` 参数：
  - **快速路径**（新）：本地 SHA == manifest 记录的 SHA → 直接 return，**0 次 API**
  - **慢速路径**（原行为）：未命中或 SHA 变更 → GET + PUT；上传成功时 \`record\` 新 SHA
- \`UploadMediaForDeploy\` 入口 \`loadCdnManifest\`，\`defer save\`：
  - 部署中途失败不阻止已完成文件落盘缓存（下次继续享受快路径）
  - \`save\` 失败只 warn，不影响部署成功
- \`TestUpload\` 传 \`nil manifest\`，保持"每次都打 API"语义用于配置验证

## 收益量化

大图站 100 张图：
| 场景 | 原实现 API 调用 | 本 PR |
|---|---|---|
| 首次部署 | 200 (100 GET + 100 PUT) | 200（不变） |
| 重复部署（无文件变更） | 200（GET 验证 + 跳过 PUT） | **0** |
| 重复部署（10 张图变更） | 200（GET 100 + PUT 10） | 120（GET 10 + PUT 10）|

## Test plan

- [x] 4 个新增单测：空加载 / 读写往返 / 坏 JSON 降级 / record 更新旧值
- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：
  - 首次部署后检查 \`<site>/.cdn-manifest.json\` 存在且包含所有 remotePath
  - 第二次部署日志应显示大部分文件被跳过（不打 API）
  - 修改一张图再部署 → 仅该文件走 GET + PUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)