### PR TITLE
fix(cdn): 部署后清理远端孤儿文件 (#47)

### DIFF
--- a/backend/internal/service/cdn_manifest.go
+++ b/backend/internal/service/cdn_manifest.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// cdnManifest 记录一份"远端路径 → 本地 git blob SHA"的映射。
+// 持久化在 <appDir>/.cdn-manifest.json，用于跨次部署避免重复的 GET+PUT（见 issue #45）。
+//
+// 核心假设：一旦某个 remotePath 在远端上传成功，本地就会记录对应的
+// blob SHA；下次部署时若本地算出同样的 SHA，就可以直接跳过 API 调用，
+// 不需要再向 GitHub 查询远端状态。
+type cdnManifest struct {
+	mu      sync.Mutex
+	Entries map[string]string `json:"entries"` // remotePath → localSHA
+}
+
+// loadCdnManifest 从 appDir 读取 manifest；文件不存在或解析失败时返回空白 manifest。
+func loadCdnManifest(appDir string) *cdnManifest {
+	m := &cdnManifest{Entries: make(map[string]string)}
+	data, err := os.ReadFile(filepath.Join(appDir, ".cdn-manifest.json"))
+	if err != nil {
+		return m
+	}
+	// 忽略解析错误：异常文件当作"空缓存"，迫使所有文件都重新走一遍完整路径。
+	_ = json.Unmarshal(data, m)
+	if m.Entries == nil {
+		m.Entries = make(map[string]string)
+	}
+	return m
+}
+
+// save 将 manifest 写回磁盘；并发安全。
+func (m *cdnManifest) save(appDir string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(appDir, ".cdn-manifest.json"), data, 0o644)
+}
+
+// hit 查询某个远端路径的已知 SHA；未命中返回 ""，false。
+func (m *cdnManifest) hit(remotePath string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sha, ok := m.Entries[remotePath]
+	return sha, ok
+}
+
+// record 写入一次成功上传后的映射。
+func (m *cdnManifest) record(remotePath, sha string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Entries[remotePath] = sha
+}

--- a/backend/internal/service/cdn_manifest_test.go
+++ b/backend/internal/service/cdn_manifest_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCdnManifest_EmptyLoadReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	m := loadCdnManifest(dir)
+	if m == nil {
+		t.Fatal("loadCdnManifest returned nil")
+	}
+	if len(m.Entries) != 0 {
+		t.Errorf("expected empty entries, got %v", m.Entries)
+	}
+}
+
+func TestCdnManifest_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	m := loadCdnManifest(dir)
+	m.record("post-images/a.png", "sha-a")
+	m.record("post-images/b.png", "sha-b")
+	if err := m.save(dir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// 再读一次应该拿到同样的内容
+	m2 := loadCdnManifest(dir)
+	if sha, ok := m2.hit("post-images/a.png"); !ok || sha != "sha-a" {
+		t.Errorf("expected a.png sha-a, got %v %v", sha, ok)
+	}
+	if sha, ok := m2.hit("post-images/b.png"); !ok || sha != "sha-b" {
+		t.Errorf("expected b.png sha-b, got %v %v", sha, ok)
+	}
+	if _, ok := m2.hit("missing.png"); ok {
+		t.Error("expected miss on unknown path")
+	}
+}
+
+func TestCdnManifest_CorruptFileTreatedAsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// 写一个无法解析的 JSON
+	_ = os.WriteFile(filepath.Join(dir, ".cdn-manifest.json"), []byte("{{{not json"), 0o644)
+
+	m := loadCdnManifest(dir)
+	if m == nil {
+		t.Fatal("loadCdnManifest returned nil")
+	}
+	if len(m.Entries) != 0 {
+		t.Errorf("corrupt manifest should fall back to empty, got %v", m.Entries)
+	}
+	// 并且 record / save 仍应工作
+	m.record("x", "y")
+	if err := m.save(dir); err != nil {
+		t.Fatalf("save after corrupt reload: %v", err)
+	}
+}
+
+func TestCdnManifest_RecordUpdatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	m := loadCdnManifest(dir)
+	m.record("a.png", "old-sha")
+	m.record("a.png", "new-sha")
+	sha, ok := m.hit("a.png")
+	if !ok || sha != "new-sha" {
+		t.Errorf("expected new-sha, got %v %v", sha, ok)
+	}
+}

--- a/backend/internal/service/cdn_upload_service.go
+++ b/backend/internal/service/cdn_upload_service.go
@@ -132,8 +132,11 @@ type githubContentsResponse struct {
 	SHA string `json:"sha"`
 }
 
-// uploadToGitHub 通过 GitHub Contents API 上传单个文件
-func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.CdnSetting, localFilePath, remotePath string) error {
+// uploadToGitHub 通过 GitHub Contents API 上传单个文件。
+// manifest 非 nil 时走本地 manifest 缓存（#45）：若 remotePath 在上次成功上传后
+// 仍是同一个 SHA，直接跳过整个 API 往返；否则仍需一次 GET 查远端 SHA 做增量。
+// 成功上传后向 manifest 记录新的 (remotePath → localSHA)。
+func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.CdnSetting, localFilePath, remotePath string, manifest *cdnManifest) error {
 	// 读取本地文件
 	data, err := os.ReadFile(localFilePath)
 	if err != nil {
@@ -148,10 +151,21 @@ func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.Cd
 	// 计算本地文件 SHA（git blob SHA1）
 	localSHA := gitBlobSHA(data)
 
-	// 检查文件是否已存在
+	// 快速路径：本地 manifest 命中且 SHA 未变，直接跳过 API。
+	// 放开这条后大部分"重复部署"场景都不再调用 GitHub API，配额保留给真正的变更。
+	if manifest != nil {
+		if cached, ok := manifest.hit(remotePath); ok && cached == localSHA {
+			return nil
+		}
+	}
+
+	// 慢路径：manifest 未命中或 SHA 变更，还需一次 GET 拿远端 SHA 做增量更新
 	existingSHA, err := s.getGithubFileSHA(ctx, setting, remotePath, branch)
 	if err == nil && existingSHA == localSHA {
-		// 文件内容相同，跳过
+		// 文件内容相同，跳过上传，但补录到 manifest 避免下次再 GET
+		if manifest != nil {
+			manifest.record(remotePath, localSHA)
+		}
 		return nil
 	}
 
@@ -207,6 +221,10 @@ func (s *CdnUploadService) uploadToGitHub(ctx context.Context, setting domain.Cd
 		}
 	}
 
+	// 成功：把新 SHA 写入 manifest，后续部署可以直接走快速路径
+	if manifest != nil {
+		manifest.record(remotePath, localSHA)
+	}
 	return nil
 }
 
@@ -286,8 +304,8 @@ func (s *CdnUploadService) TestUpload(ctx context.Context) (string, error) {
 	}
 	remotePath := ResolveSavePath(savePath, "gridea-test.txt")
 
-	// 上传
-	if err := s.uploadToGitHub(ctx, setting, tmpFile.Name(), remotePath); err != nil {
+	// 上传（测试场景不走 manifest 缓存：每次都实际触达 API 以便验证配置）
+	if err := s.uploadToGitHub(ctx, setting, tmpFile.Name(), remotePath, nil); err != nil {
 		return "", err
 	}
 
@@ -306,6 +324,15 @@ func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir stri
 	if !setting.Enabled || setting.GithubToken == "" {
 		return nil
 	}
+
+	// 加载本地 manifest：命中的文件跳过整轮 API 调用（#45）
+	manifest := loadCdnManifest(appDir)
+	defer func() {
+		// 无论成功失败都持久化已有进度，单文件失败不影响其它文件的快路径
+		if err := manifest.save(appDir); err != nil {
+			logger(fmt.Sprintf("警告：写入 CDN manifest 失败（下次将重新全量检查）: %v", err))
+		}
+	}()
 
 	// 需要扫描的目录
 	mediaDirs := []string{"post-images", "images", "media"}
@@ -367,7 +394,7 @@ func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir stri
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			if err := s.uploadToGitHub(gCtx, setting, f.localPath, f.remotePath); err != nil {
+			if err := s.uploadToGitHub(gCtx, setting, f.localPath, f.remotePath, manifest); err != nil {
 				logger(fmt.Sprintf("上传 %s 失败: %v", f.remotePath, err))
 				return nil // 单个文件失败不中断整个上传
 			}
@@ -383,7 +410,90 @@ func (s *CdnUploadService) UploadMediaForDeploy(ctx context.Context, appDir stri
 		return fmt.Errorf("上传媒体文件失败: %w", err)
 	}
 
+	// 清理孤儿：manifest 中有、但本次扫描不存在的 remotePath。
+	// 只基于 manifest 做对比，不做"列整库 diff"，天然安全：
+	// 如果用户在同一个 CDN 仓库里还有其它非 Gridea 上传的文件，不会被误删。
+	localSet := make(map[string]struct{}, len(filesToUpload))
+	for _, f := range filesToUpload {
+		localSet[f.remotePath] = struct{}{}
+	}
+	var orphans []string
+	for remotePath := range manifest.Entries {
+		if _, exists := localSet[remotePath]; !exists {
+			orphans = append(orphans, remotePath)
+		}
+	}
+	if len(orphans) > 0 {
+		logger(fmt.Sprintf("检测到 %d 个 CDN 孤儿文件（本地已删除但 CDN 仍存在），开始清理...", len(orphans)))
+		deleted := 0
+		for _, remotePath := range orphans {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := s.deleteFromGitHub(ctx, setting, remotePath); err != nil {
+				// 单文件删除失败不阻塞：下次部署还会再尝试
+				logger(fmt.Sprintf("清理 %s 失败（将下次重试）: %v", remotePath, err))
+				continue
+			}
+			manifest.mu.Lock()
+			delete(manifest.Entries, remotePath)
+			manifest.mu.Unlock()
+			deleted++
+		}
+		logger(fmt.Sprintf("CDN 孤儿清理完成：成功删除 %d / %d 个文件", deleted, len(orphans)))
+	}
+
 	logger(fmt.Sprintf("CDN 上传完成，共上传 %d 个文件", uploadCount))
+	return nil
+}
+
+// deleteFromGitHub 从 GitHub CDN 仓库里删除一个已上传的文件。
+// 先 GET 当前 SHA，再 DELETE（Contents API 要求提供 sha 防覆盖冲突）。
+func (s *CdnUploadService) deleteFromGitHub(ctx context.Context, setting domain.CdnSetting, remotePath string) error {
+	branch := setting.GithubBranch
+	if branch == "" {
+		branch = "main"
+	}
+
+	// 1. 拿远端 SHA；404 认为已经不存在，视作删除成功
+	sha, err := s.getGithubFileSHA(ctx, setting, remotePath, branch)
+	if err != nil {
+		// getGithubFileSHA 把"文件不存在"当成 error —— 这里视作孤儿已消失
+		return nil
+	}
+
+	// 2. DELETE 请求
+	body := map[string]any{
+		"message": fmt.Sprintf("Delete orphan %s via Gridea Pro", remotePath),
+		"sha":     sha,
+		"branch":  branch,
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s",
+		setting.GithubUser, setting.GithubRepo, remotePath)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, strings.NewReader(string(bodyJSON)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+setting.GithubToken)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient(ctx).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil // 已消失
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

修复 #47：原 CDN 上传从不清理远端 —— 本地删除过的图片在 CDN 仓库里永远保留，通过公开 CDN URL 仍可访问，对隐私 / 版权都是泄漏点。

## 修复方案

- \`UploadMediaForDeploy\` 在批量上传结束后基于 **manifest** 计算孤儿：
  > manifest 中记录、但本次扫描不再存在的 remotePath
- **基于 manifest（而非 GitHub Git Tree 全库）**做对比 —— 这是关键安全性：
  - 只清理 Gridea 自己上传过的文件（manifest 是白名单）
  - 用户在同一 CDN 仓库手动上传的非 Gridea 文件永远不会被触碰
- 新增 \`deleteFromGitHub\`：GET 当前 SHA → DELETE Contents API → 404 视为已消失（幂等）
- 成功删除后从 manifest 移除，失败只 warn 让下次重试

## 依赖关系

本 PR **依赖 #45 的 manifest**（\`cdn_manifest.go\`）。为让本 PR 独立可合，把 manifest 代码也一并包含了。若 #45 先合并，本 PR 的冲突会是"manifest 代码重复"，可直接以本 PR 的版本为准。

## 未纳入

- 其它 CDN provider（目前只有 GitHub 一种）
- 跨站点 manifest 合并（每个站点自己的 \`<appDir>/.cdn-manifest.json\` 独立，天然隔离，无需合并）

## Test plan

- [x] \`go build\` / \`go vet\` 通过
- [x] 原有 manifest 的 4 个单测依旧绿
- [ ] 人工回归：
  - 首次部署 3 张图（manifest 记录 A/B/C）
  - 本地删除 B 重新部署 → 日志显示"1 个孤儿"，GitHub 仓库查到 B 被 delete commit 移除，manifest 剩 A/C
  - 手动在 CDN 仓库里扔一个"不是 Gridea 放的文件" → 再部署不会被清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)