### PR TITLE
fix(deploy): SFTP/FTP 改为 staging + 原子 rename 切换 (#40)

### DIFF
--- a/backend/internal/deploy/ftp_deployer.go
+++ b/backend/internal/deploy/ftp_deployer.go
@@ -73,16 +73,18 @@ func (p *FtpProvider) Deploy(ctx context.Context, outputDir string, setting *dom
 
 	logger("FTP 连接成功")
 
-	// 4. 清理远程目录
-	logger(fmt.Sprintf("正在清理远程目录: %s", remotePath))
-	p.cleanRemoteDir(conn, remotePath)
+	// 4. 原子切换策略（issue #40）：先上传到 <remotePath>.new-<ts>，成功后 rename。
+	//    FTP 的 Rename 由 RNFR/RNTO 组合实现，大多数服务器都支持；同卷下接近原子。
+	ts := time.Now().Format("20060102-150405")
+	stagingPath := remotePath + ".new-" + ts
+	backupPath := remotePath + ".old-" + ts
 
-	// 确保远程目录存在
-	_ = conn.MakeDir(remotePath)
+	logger(fmt.Sprintf("正在上传到暂存目录: %s（旧站点保持可用）", stagingPath))
+	p.mkdirAll(conn, stagingPath)
 
-	// 5. 上传文件
+	// 5. 上传文件到 staging
 	fileCount := 0
-	err = filepath.Walk(outputDir, func(localPath string, info os.FileInfo, walkErr error) error {
+	uploadErr := filepath.Walk(outputDir, func(localPath string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -111,7 +113,7 @@ func (p *FtpProvider) Deploy(ctx context.Context, outputDir string, setting *dom
 		if err != nil {
 			return err
 		}
-		remoteFile := path.Join(remotePath, filepath.ToSlash(relPath))
+		remoteFile := path.Join(stagingPath, filepath.ToSlash(relPath))
 
 		// 创建远程目录
 		remoteDir := path.Dir(remoteFile)
@@ -130,8 +132,41 @@ func (p *FtpProvider) Deploy(ctx context.Context, outputDir string, setting *dom
 		return nil
 	})
 
-	if err != nil {
-		return err
+	if uploadErr != nil {
+		logger(fmt.Sprintf("上传失败，正在清理暂存目录 %s...", stagingPath))
+		p.cleanRemoteDir(conn, stagingPath)
+		_ = conn.RemoveDir(stagingPath)
+		return uploadErr
+	}
+
+	// 6. 原子切换：先看旧目录是否存在
+	logger("上传完成，正在切换到新版本（FTP rename）...")
+	oldExists := true
+	if err := conn.ChangeDir(remotePath); err != nil {
+		oldExists = false
+	} else {
+		_ = conn.ChangeDir("/") // 切回根目录
+	}
+	if oldExists {
+		if err := conn.Rename(remotePath, backupPath); err != nil {
+			p.cleanRemoteDir(conn, stagingPath)
+			_ = conn.RemoveDir(stagingPath)
+			return fmt.Errorf("重命名旧目录失败: %w", err)
+		}
+	}
+	if err := conn.Rename(stagingPath, remotePath); err != nil {
+		if oldExists {
+			_ = conn.Rename(backupPath, remotePath)
+		}
+		p.cleanRemoteDir(conn, stagingPath)
+		_ = conn.RemoveDir(stagingPath)
+		return fmt.Errorf("重命名新目录失败: %w", err)
+	}
+
+	// 7. 清理旧备份（best-effort）
+	if oldExists {
+		p.cleanRemoteDir(conn, backupPath)
+		_ = conn.RemoveDir(backupPath)
 	}
 
 	logger(fmt.Sprintf("✅ FTP 部署成功！共上传 %d 个文件到 %s", fileCount, remotePath))

--- a/backend/internal/deploy/sftp_deployer.go
+++ b/backend/internal/deploy/sftp_deployer.go
@@ -88,18 +88,24 @@ func (p *SftpProvider) Deploy(ctx context.Context, outputDir string, setting *do
 	}
 	defer client.Close()
 
-	// 5. 清理远程目录
-	logger(fmt.Sprintf("正在清理远程目录: %s", remotePath))
-	p.cleanRemoteDir(client, remotePath)
+	// 5. 原子切换策略（issue #40）：
+	//    a. 上传到 <remotePath>.new-<ts>（staging），旧站点完好无损
+	//    b. 全部成功 → 把旧目录 rename 到 <remotePath>.old-<ts>，再把 staging rename 为 remotePath
+	//    c. 失败 → 清理 staging，旧站点保持原样，访客零感知
+	//
+	// 好处：上传期间访客全程访问旧版本；中途断网不毁站；失败可直接 dropping staging 重新开始。
+	ts := time.Now().Format("20060102-150405")
+	stagingPath := remotePath + ".new-" + ts
+	backupPath := remotePath + ".old-" + ts
 
-	// 确保远程目录存在
-	if err := client.MkdirAll(remotePath); err != nil {
-		return fmt.Errorf("创建远程目录失败: %w", err)
+	logger(fmt.Sprintf("正在上传到暂存目录: %s（旧站点保持可用）", stagingPath))
+	if err := client.MkdirAll(stagingPath); err != nil {
+		return fmt.Errorf("创建暂存目录失败: %w", err)
 	}
 
-	// 6. 上传文件
+	// 6. 上传文件到 staging
 	fileCount := 0
-	err = filepath.Walk(outputDir, func(localPath string, info os.FileInfo, err error) error {
+	uploadErr := filepath.Walk(outputDir, func(localPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -128,8 +134,8 @@ func (p *SftpProvider) Deploy(ctx context.Context, outputDir string, setting *do
 		if err != nil {
 			return err
 		}
-		// 远程路径始终使用 Unix 风格
-		remoteFile := path.Join(remotePath, filepath.ToSlash(relPath))
+		// 远程路径始终使用 Unix 风格；上传到 staging 目录
+		remoteFile := path.Join(stagingPath, filepath.ToSlash(relPath))
 
 		// 创建远程目录
 		remoteDir := path.Dir(remoteFile)
@@ -150,8 +156,44 @@ func (p *SftpProvider) Deploy(ctx context.Context, outputDir string, setting *do
 		return nil
 	})
 
-	if err != nil {
-		return err
+	if uploadErr != nil {
+		// 清理 staging（尽力而为），旧站点保持原样
+		logger(fmt.Sprintf("上传失败，正在清理暂存目录 %s...", stagingPath))
+		p.cleanRemoteDir(client, stagingPath)
+		_ = client.RemoveDirectory(stagingPath)
+		return uploadErr
+	}
+
+	// 7. 原子切换：rename 旧→backup、rename staging→remote
+	logger("上传完成，正在切换到新版本（原子 rename）...")
+
+	// 旧目录可能不存在（首次部署），尝试 rename 失败不视为错误
+	oldExists := false
+	if _, err := client.Stat(remotePath); err == nil {
+		oldExists = true
+	}
+	if oldExists {
+		if err := client.Rename(remotePath, backupPath); err != nil {
+			// 清理 staging，保留旧目录
+			p.cleanRemoteDir(client, stagingPath)
+			_ = client.RemoveDirectory(stagingPath)
+			return fmt.Errorf("重命名旧目录失败: %w", err)
+		}
+	}
+	if err := client.Rename(stagingPath, remotePath); err != nil {
+		// 尝试把 backup 改回来，尽量不让站点挂掉
+		if oldExists {
+			_ = client.Rename(backupPath, remotePath)
+		}
+		p.cleanRemoteDir(client, stagingPath)
+		_ = client.RemoveDirectory(stagingPath)
+		return fmt.Errorf("重命名新目录失败: %w", err)
+	}
+
+	// 8. 清理旧备份（best-effort，失败不影响部署成功）
+	if oldExists {
+		p.cleanRemoteDir(client, backupPath)
+		_ = client.RemoveDirectory(backupPath)
 	}
 
 	logger(fmt.Sprintf("✅ SFTP 部署成功！共上传 %d 个文件到 %s", fileCount, remotePath))


### PR DESCRIPTION
## Summary

修复 #40（P0 数据丢失）：SFTP / FTP 部署"先 \`cleanRemoteDir\` 再串行上传"：
- 清空 → 上传完成 之间的窗口访客访问站点是 **404**
- 中途断网 / 进程被杀 → 远端"一半新 / 一半空 / 旧文件全丢"，**无回滚机制**
- \`cleanRemoteDir\` 还静默吞删除错误，残留与新文件混在一起更难排查

## 修复方案（SFTP + FTP 对称）

- 上传到 \`<remotePath>.new-<ts>\`（staging 目录），旧站点全程可用 ✅
- 全部上传成功后做**原子 rename**：
  1. \`<remotePath> → <remotePath>.old-<ts>\`（旧版本 backup）
  2. \`<remotePath>.new-<ts> → <remotePath>\`（新版本上位）
  3. 清理 \`.old-<ts>\`（best-effort，失败不影响部署成功）
- **故障路径**：
  - 上传途中失败 → 清理 staging，旧站点保持原样不动
  - Rename 第 2 步失败 → 尝试把 \`.old\` 改回 \`<remotePath>\`，最大程度不让站点挂掉
- 首次部署（旧目录不存在）：检查 \`Stat\` / \`ChangeDir\` 确认存在性，不存在则跳过 backup rename

同卷下 SFTP \`Rename\` / FTP \`RNFR+RNTO\` 都是 O(1) 元数据操作，切换窗口接近原子。

## 副作用

部署期间远端多出 2 个临时目录（\`.new-<ts>\` / \`.old-<ts>\`），正常路径下 cleanup 都会做掉；只有 "\`.old-\` 清理失败"的情况下会留残，用户可手动删除。

## Test plan

- [x] \`go build\` / \`go vet\` 通过
- [ ] 人工回归：
  - 正常发布 → 访客期间访问持续可用；远端最终只剩 \`<remotePath>\`
  - 上传中途杀进程 → \`<remotePath>\` 仍是旧版本，手动 \`ls\` 可见残留的 \`.new-\` 目录
  - 首次部署（远端为空）→ 跳过 backup rename，正常上线

🤖 Generated with [Claude Code](https://claude.com/claude-code)