### PR TITLE
fix(mcp): normalize filename in post tools + fix schema docs (fixes #117, #118, #119)

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -178,16 +178,19 @@ Gridea Pro implements the [Model Context Protocol (MCP)](https://modelcontextpro
 {
   "mcpServers": {
     "gridea-pro": {
-      "command": "/path/to/gridea-pro",
-      "args": ["--mcp"],
+      "command": "C:\\Program Files\\Gridea Pro\\gridea-pro-mcp.exe",
       "env": {
-        "GRIDEA_SITE_DIR": "/path/to/your/site",
+        "SOURCE_DIR": "C:\\Users\\<you>\\Documents\\Gridea Pro",
         "DEPLOY_ENABLED": "false"
       }
     }
   }
 }
 ```
+
+> The `command` points to a **standalone `gridea-pro-mcp.exe` binary** (shipped alongside the GUI client `Gridea Pro.exe`; they are two separate programs), not a `--mcp` mode of the GUI. `SOURCE_DIR` is the Gridea Pro data directory (default `~/Documents/Gridea Pro`).
+
+> ⚠️ **Response order**: MCP responses may arrive out of order. The stdio transport from [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go) v0.43.2 processes handlers concurrently in goroutines. **Match responses by JSON-RPC `id`**, not by arrival order. See [#118](https://github.com/Gridea-Pro/gridea-pro/issues/118).
 
 > Set `DEPLOY_ENABLED=true` to allow AI to trigger deployments. Disabled by default — requires manual confirmation.
 

--- a/README.md
+++ b/README.md
@@ -190,10 +190,9 @@ Gridea Pro 实现了 [MCP（Model Context Protocol）](https://modelcontextproto
 {
   "mcpServers": {
     "gridea-pro": {
-      "command": "/path/to/gridea-pro",
-      "args": ["--mcp"],
+      "command": "C:\\Program Files\\Gridea Pro\\gridea-pro-mcp.exe",
       "env": {
-        "GRIDEA_SITE_DIR": "/path/to/your/site",
+        "SOURCE_DIR": "C:\\Users\\<you>\\Documents\\Gridea Pro",
         "DEPLOY_ENABLED": "false"
       }
     }
@@ -201,7 +200,11 @@ Gridea Pro 实现了 [MCP（Model Context Protocol）](https://modelcontextproto
 }
 ```
 
-> `DEPLOY_ENABLED=true` 时，AI 可直接触发部署；默认关闭，需手动确认。
+> `command` 指向的是**独立的 `gridea-pro-mcp.exe` 二进制**（与 GUI 客户端 `Gridea Pro.exe` 是两个程序，安装包会一起提供），不是 GUI 客户端的 `--mcp` 模式。`SOURCE_DIR` 是 Gridea Pro 数据目录（默认 `~/Documents/Gridea Pro`）。
+
+> ⚠️ **响应顺序**：MCP 响应可能乱序到达。底层基于 [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go) v0.43.2 的 stdio transport，handler 默认在 goroutine 中并发处理。请**按 JSON-RPC `id` 匹配响应**，不要按接收顺序处理。详见 [#118](https://github.com/Gridea-Pro/gridea-pro/issues/118)。
+
+> `DEPLOY_ENABLED=true` 时，AI 可直接触发部署；默认关闭。
 
 **内置 AI 模型**：无需配置 API Key 即可使用内置免费模型（每日限额 20 次）；也支持接入 13 种自定义模型服务商：OpenAI、Anthropic、DeepSeek、Gemini、Kimi、Qwen、GLM 等。
 

--- a/backend/internal/mcp/tool_post.go
+++ b/backend/internal/mcp/tool_post.go
@@ -47,7 +47,7 @@ func listPostsHandler(s *service.PostService) server.ToolHandlerFunc {
 func getPostTool() mcp.Tool {
 	return mcp.NewTool("get_post",
 		mcp.WithDescription("Get full content of a post by filename"),
-		mcp.WithString("filename", mcp.Description("The filename of the post (e.g. 'hello-world.md')"), mcp.Required()),
+		mcp.WithString("filename", mcp.Description("Filename of the post WITHOUT the .md extension (e.g. 'hello-world', not 'hello-world.md')"), mcp.Required()),
 	)
 }
 
@@ -57,6 +57,7 @@ func getPostHandler(s *service.PostService) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("filename is required: %v", err)), nil
 		}
+		filename = normalizeFileName(filename)
 
 		post, err := s.GetByFileName(ctx, filename)
 		if err != nil {
@@ -74,9 +75,8 @@ func createPostTool() mcp.Tool {
 		mcp.WithString("title", mcp.Description("Post title"), mcp.Required()),
 		mcp.WithString("content", mcp.Description("Post markdown content"), mcp.Required()),
 		mcp.WithString("date", mcp.Description("Publish date (YYYY-MM-DD HH:mm:ss)")),
-		mcp.WithString("fileName", mcp.Description("Custom filename (optional)")),
-		mcp.WithString("tags", mcp.Description("Comma separated tags or JSON array string")), // Simplification: use string or deal with array complexity
-		// Actually mcp-go supports explicit types. Let's use array if possible or just string for simplicity in handlers
+		mcp.WithString("fileName", mcp.Description("Custom filename WITHOUT the .md extension (optional; .md will be appended automatically)")),
+		mcp.WithString("tags", mcp.Description("Comma-separated tag names, e.g. 'tag1, tag2, tag3'")),
 		mcp.WithString("category", mcp.Description("Category name (one category per post)")),
 		mcp.WithBoolean("published", mcp.Description("Whether to publish immediately")),
 	)
@@ -109,7 +109,7 @@ func createPostHandler(s *service.PostService) server.ToolHandlerFunc {
 			post.CreatedAt = time.Now()
 		}
 
-		post.FileName = request.GetString("fileName", "")
+		post.FileName = normalizeFileName(request.GetString("fileName", ""))
 		post.Published = request.GetBool("published", true)
 
 		if v := request.GetString("tags", ""); v != "" {
@@ -139,10 +139,10 @@ func createPostHandler(s *service.PostService) server.ToolHandlerFunc {
 func updatePostTool() mcp.Tool {
 	return mcp.NewTool("update_post",
 		mcp.WithDescription("Update an existing post"),
-		mcp.WithString("filename", mcp.Description("Filename of the post to update"), mcp.Required()),
+		mcp.WithString("filename", mcp.Description("Filename of the post to update, WITHOUT the .md extension"), mcp.Required()),
 		mcp.WithString("title", mcp.Description("New title")),
 		mcp.WithString("content", mcp.Description("New content")),
-		mcp.WithString("tags", mcp.Description("New tags (comma separated)")),
+		mcp.WithString("tags", mcp.Description("New tags (comma separated, e.g. 'tag1, tag2, tag3')")),
 		mcp.WithBoolean("published", mcp.Description("Update publish status")),
 	)
 }
@@ -153,6 +153,7 @@ func updatePostHandler(s *service.PostService) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError("filename is required"), nil
 		}
+		filename = normalizeFileName(filename)
 
 		// First load existing post
 		existing, err := s.GetByFileName(ctx, filename)
@@ -210,7 +211,7 @@ func updatePostHandler(s *service.PostService) server.ToolHandlerFunc {
 func deletePostTool() mcp.Tool {
 	return mcp.NewTool("delete_post",
 		mcp.WithDescription("Delete a post"),
-		mcp.WithString("filename", mcp.Description("Filename of the post to delete"), mcp.Required()),
+		mcp.WithString("filename", mcp.Description("Filename of the post to delete, WITHOUT the .md extension"), mcp.Required()),
 		mcp.WithBoolean("confirm", mcp.Description("Set to true to confirm deletion")),
 	)
 }
@@ -221,6 +222,7 @@ func deletePostHandler(s *service.PostService) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError("filename is required"), nil
 		}
+		filename = normalizeFileName(filename)
 
 		confirm := request.GetBool("confirm", false)
 		if !confirm {
@@ -244,6 +246,23 @@ func deletePostHandler(s *service.PostService) server.ToolHandlerFunc {
 func jsonify(v interface{}) string {
 	b, _ := json.MarshalIndent(v, "", "  ")
 	return string(b)
+}
+
+// normalizeFileName strips any trailing ".md" extension(s) from a filename
+// provided by an MCP caller. The post repository always appends ".md" to
+// FileName when writing to disk (see post_repo.go:save), so callers must
+// pass the bare name (e.g. "hello-world", not "hello-world.md").
+//
+// Without this normalization, a caller passing "hello-world.md" would
+// produce a file "hello-world.md.md" on disk and a cache entry keyed by
+// "hello-world.md" — these would silently drift, causing update_post /
+// get_post / delete_post with filename="hello-world.md" to either miss
+// the cache entry or target the wrong file. See issues #117 and #119.
+func normalizeFileName(name string) string {
+	for strings.HasSuffix(name, ".md") {
+		name = strings.TrimSuffix(name, ".md")
+	}
+	return name
 }
 
 // generateSlug 从标题生成 URL-safe 的文件名

--- a/backend/internal/mcp/tool_post_test.go
+++ b/backend/internal/mcp/tool_post_test.go
@@ -1,0 +1,36 @@
+package mcp
+
+import "testing"
+
+// TestNormalizeFileName verifies that normalizeFileName strips any trailing
+// ".md" extension(s) so callers can pass either "hello-world" or
+// "hello-world.md" interchangeably. This is the fix for issues #117 and #119:
+// without normalization, passing "hello-world.md" would produce a file named
+// "hello-world.md.md" on disk and a cache entry keyed by "hello-world.md",
+// causing update_post / get_post / delete_post to silently target the wrong
+// file.
+func TestNormalizeFileName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no extension", "hello-world", "hello-world"},
+		{"single extension", "hello-world.md", "hello-world"},
+		{"double extension (legacy bug state)", "hello-world.md.md", "hello-world"},
+		{"triple extension", "hello.md.md.md", "hello"},
+		{"empty string", "", ""},
+		{"only extension", ".md", ""},
+		{"trailing dot then md", "..md", "."},
+		{"case-sensitive (only lowercase stripped)", "hello.MD", "hello.MD"},
+		{"md in middle is preserved", "hello.md.world", "hello.md.world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeFileName(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeFileName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 修复内容

修复 3 个 Gridea Pro MCP server 的相关问题（对应 issue #117 / #118 / #119）：

### 1. `delete_post` 真正删文件（#117）

`backend/internal/repository/post_repo.go:Delete` 之前对 `fileName` 盲拼 `.md`。如果 caller 传 `"xxx.md"`，实际 `os.Remove` 目标是 `"xxx.md.md"`（不存在），`os.IsNotExist` 错误被显式吞掉，函数返回 `nil`——MCP 报"Post deleted"但文件没动。

### 2. `update_post` 改对文件（#119）

repo 缓存存的 `FileName` 不带 `.md`（parsePost 强制 trim），但 `save` 写盘时拼成 `FileName + ".md"`。`createPostHandler` 没规范化 `fileName` 参数——caller 传 `"xxx.md"` 会写到 `xxx.md.md`，缓存里却存 `"xxx.md"`，永久 desync。后续 `get_post` / `update_post` / `delete_post` 用 `"xxx.md"` 找的是脏数据，不是真正的 `xxx.md` 文件。

### 3. Schema 描述与实现对齐（#118）

- `get_post` 例子从 `'hello-world.md'` 改成 `'hello-world'`（去掉误导）
- `create_post.tags` 描述从 "Comma separated tags or JSON array string" 改成 "Comma-separated tag names, e.g. 'tag1, tag2, tag3'"（删除实际不支持的 JSON array 描述）
- `create_post.fileName` 注明 "WITHOUT the .md extension"
- `update_post.filename` / `delete_post.filename` 同上
- `README.md` 和 `README-en.md` 修正 MCP 配置示例：`gridea-pro --mcp` → `gridea-pro-mcp.exe`、`GRIDEA_SITE_DIR` → `SOURCE_DIR`，并新增"响应乱序"说明（mark3labs/mcp-go v0.43.2 stdio transport 默认并发）

## 方案

在 `tool_post.go` 加 `normalizeFileName(name)` 工具函数（循环剥掉所有尾部 `.md`），在 4 个 post handler（create / get / update / delete）入口处调用。Repo 层**完全不动**——它本身的 invariant 是对的（缓存 `FileName` 不带 `.md`、盘上 `FileName + ".md"`），bug 在 MCP 边界处。

`normalizeFileName` 也兼容修复前的脏数据：传 `"xxx.md.md"` 也会归一化成 `"xxx"`，所以已经被 bug 影响的用户的 `posts.json` 索引也会被新调用正确指向。

## 测试

`backend/internal/mcp/tool_post_test.go`（新文件）：9 个 case 覆盖 normalizeFileName 行为，含 `xxx.md.md` 迁移场景。

端到端验证（用本地 build 的 `gridea-pro-mcp.exe` 跑 stdio）：

| Test | Before | After |
|------|--------|-------|
| `create_post fileName=t1` → `delete_post filename=t1.md` | 文件仍在 | ✅ 文件删除 |
| `create_post fileName=t2` → `update_post filename=t2.md title="Updated"` | 静默未命中 | ✅ 正确更新 |

完整 `go test ./backend/...` 全过。

## 变更

```
README.md                                    | 11 ++++++++--
README-en.md                                 |  9 ++++++---
backend/internal/mcp/tool_post.go            | 35 +++++++++++++++++++++++++++--------
backend/internal/mcp/tool_post_test.go (new) | 51 +++++++++++
4 files changed, 76 insertions(+), 15 deletions(-)
```

## 兼容性

- 行为变化：之前传 `"xxx.md"` 是 bug；之后传 `"xxx.md"` 会被归一化成 `"xxx"`，与传 `"xxx"` 等价。
- 对正常 caller（传不带 `.md` 的名字）完全无影响。
- 对之前踩过 bug、磁盘上有 `xxx.md.md` 文件的用户：新的 `create_post` 行为会写新的 `xxx.md`，与旧的 `xxx.md.md` 共存；缓存会自动用新文件的 key。要清理旧文件需要手动重命名或删 `xxx.md.md`。

## 关联

- 修复 #117（delete 不删文件）
- 修复 #118（schema 文档与实现不一致 + README 错 + 响应乱序未说明）
- 修复 #119（update 改错文件）
