### PR TITLE
fix(repo): CopyFile 同文件截断零字节 + 源文件路径误删 (#127)

### DIFF
--- a/backend/internal/repository/helper.go
+++ b/backend/internal/repository/helper.go
@@ -140,6 +140,10 @@ func sameCleanPath(src, dst string) bool {
 
 // cleanAbsPath 先 Clean 再 Abs，用于消除路径中的 ../、多余分隔符等。
 // Abs 失败时安全退化为 Clean 后的结果。
+//
+// 注意：filepath.Abs 对相对路径会基于 os.Getwd()（Wails 进程 CWD）解析，
+// 而非用户站点目录。调用方必须传入绝对路径；本仓库调用方（FeatureImage.Path）
+// 均来自文件选择器，天然为绝对路径。
 func cleanAbsPath(path string) string {
 	cleaned := filepath.Clean(path)
 	abs, err := filepath.Abs(cleaned)

--- a/backend/internal/repository/helper.go
+++ b/backend/internal/repository/helper.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 // Helper functions for JSON DB
@@ -85,6 +87,10 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 }
 
 func CopyFile(src, dst string) error {
+	if sameFilePath(src, dst) {
+		return nil
+	}
+
 	sourceFile, err := os.Open(src)
 	if err != nil {
 		return err
@@ -99,6 +105,64 @@ func CopyFile(src, dst string) error {
 
 	_, err = io.Copy(destFile, sourceFile)
 	return err
+}
+
+// sameFilePath 判断 src 和 dst 是否指向同一个文件。
+// 分两层防御：先做路径规范化比较（处理 \ vs /、大小写等差异），
+// 若仍无法判定则通过 os.Stat + os.SameFile 对比 inode。
+// 用于 CopyFile 入口守卫，避免同一文件被 os.Create 截断为零字节。
+func sameFilePath(src, dst string) bool {
+	if sameCleanPath(src, dst) {
+		return true
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return false
+	}
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(srcInfo, dstInfo)
+}
+
+// sameCleanPath 将两个路径规范化为绝对路径后比较。
+// Windows 下用 EqualFold 处理大小写不敏感。
+func sameCleanPath(src, dst string) bool {
+	src = cleanAbsPath(src)
+	dst = cleanAbsPath(dst)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(src, dst)
+	}
+	return src == dst
+}
+
+// cleanAbsPath 先 Clean 再 Abs，用于消除路径中的 ../、多余分隔符等。
+// Abs 失败时安全退化为 Clean 后的结果。
+func cleanAbsPath(path string) string {
+	cleaned := filepath.Clean(path)
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	return abs
+}
+
+// pathInsideDir 判断 path 是否严格位于 dir 目录内部（排除 dir 自身及父目录）。
+// 用于 CopyFile 后将已复制到 postImageDir 内的源文件安全删除：
+// 仅当源文件已在目标目录内时才删除，防御路径穿越。
+func pathInsideDir(path, dir string) bool {
+	pathAbs := cleanAbsPath(path)
+	dirAbs := cleanAbsPath(dir)
+	rel, err := filepath.Rel(dirAbs, pathAbs)
+	if err != nil {
+		return false
+	}
+	// 排除 dir 自身（"."）、父目录（".."）、绝对路径（跨盘符/卷），
+	// 以及以 "..\" 或 "../" 开头的相对路径（在 dir 外但 Rel 未判定为 ".."）。
+	return rel != "." && rel != ".." && !filepath.IsAbs(rel) &&
+		!strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 // FileMutex 管理对应文件的读写锁

--- a/backend/internal/repository/post_repo.go
+++ b/backend/internal/repository/post_repo.go
@@ -182,11 +182,11 @@ func (r *postRepository) save(ctx context.Context, post *domain.Post, isUpdate b
 		ext := filepath.Ext(post.FeatureImage.Name)
 		newPath := filepath.Join(postImageDir, post.FileName+ext)
 		// 源路径与目标路径相同时跳过复制，避免 CopyFile 将文件截断为 0 字节
-		if post.FeatureImage.Path == newPath {
+		if sameFilePath(post.FeatureImage.Path, newPath) {
 			feature = "/post-images/" + post.FileName + ext
 		} else if err := CopyFile(post.FeatureImage.Path, newPath); err == nil {
 			feature = "/post-images/" + post.FileName + ext
-			if strings.Contains(post.FeatureImage.Path, postImageDir) {
+			if pathInsideDir(post.FeatureImage.Path, postImageDir) {
 				_ = os.Remove(post.FeatureImage.Path)
 			}
 		}

--- a/backend/internal/repository/post_repo_test.go
+++ b/backend/internal/repository/post_repo_test.go
@@ -45,6 +45,7 @@ func TestCopyFileSamePathDoesNotTruncate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// 同文件、不同写法（Windows \→/）：走 sameCleanPath 或 os.SameFile
 	if err := CopyFile(path, filepath.ToSlash(path)); err != nil {
 		t.Fatal(err)
 	}
@@ -55,6 +56,23 @@ func TestCopyFileSamePathDoesNotTruncate(t *testing.T) {
 	}
 	if !bytes.Equal(got, original) {
 		t.Fatalf("CopyFile truncated same-path copy: got %d bytes, want %d bytes", len(got), len(original))
+	}
+
+	// 语义相同、字符串不同的路径（经 /../ 规范化后等价）：
+	// 确保 sameCleanPath 的 filepath.Abs 规范化分支在 Linux CI 中也被覆盖。
+	altPath := filepath.Dir(path) + string(os.PathSeparator) + ".." +
+		string(os.PathSeparator) + filepath.Base(filepath.Dir(path)) +
+		string(os.PathSeparator) + filepath.Base(path)
+	if err := CopyFile(path, altPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got2, original) {
+		t.Fatalf("CopyFile truncated same-file (..-normalized) copy: got %d bytes, want %d bytes", len(got2), len(original))
 	}
 }
 

--- a/backend/internal/repository/post_repo_test.go
+++ b/backend/internal/repository/post_repo_test.go
@@ -1,6 +1,15 @@
 package repository
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gridea-pro/backend/internal/domain"
+)
 
 // TestNormalizeFileName 验证 repo 入口归一：去掉末尾 .md（含历史遗留的多重 .md），
 // 大小写敏感（只剥小写 .md，与 save 补的小写 .md 对齐），中间的 .md 保留。
@@ -26,5 +35,70 @@ func TestNormalizeFileName(t *testing.T) {
 				t.Errorf("normalizeFileName(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCopyFileSamePathDoesNotTruncate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cover.png")
+	original := []byte("not a real png, but it must remain intact")
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFile(path, filepath.ToSlash(path)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("CopyFile truncated same-path copy: got %d bytes, want %d bytes", len(got), len(original))
+	}
+}
+
+func TestPostRepositoryUpdateKeepsExistingFeatureImage(t *testing.T) {
+	ctx := context.Background()
+	appDir := t.TempDir()
+	repo := NewPostRepository(appDir)
+
+	src := filepath.Join(t.TempDir(), "source-cover.png")
+	original := []byte("stable cover image bytes")
+	if err := os.WriteFile(src, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	post := &domain.Post{
+		ID:        "issue127",
+		Title:     "Issue 127",
+		CreatedAt: time.Now(),
+		Published: true,
+		Content:   "body",
+		FileName:  "issue-127",
+		FeatureImage: domain.FileInfo{
+			Name: "source-cover.png",
+			Path: src,
+		},
+	}
+	if err := repo.Create(ctx, post); err != nil {
+		t.Fatal(err)
+	}
+
+	coverPath := filepath.Join(appDir, "post-images", "issue-127.png")
+	post.FeatureImage = domain.FileInfo{
+		Name: "issue-127.png",
+		Path: filepath.ToSlash(coverPath),
+	}
+	if err := repo.Update(ctx, post); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(coverPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("existing feature image changed on update: got %d bytes, want %d bytes", len(got), len(original))
 	}
 }


### PR DESCRIPTION
## 变更说明

更新文章时若封面源路径与目标路径为同一文件（仅路径写法不同），
CopyFile 的 os.Create 会先截断文件再复制空内容，导致图片永久损坏。
同时 strings.Contains 子串匹配判断源文件归属过于宽松，可能误删文件。

修复：
1. CopyFile 入口加 sameFilePath 守卫（路径规范化 + os.SameFile inode 兜底）
2. 源文件归属判断从 strings.Contains 改为 pathInsideDir（filepath.Rel 严格检查）
3. 补齐两个回归测试


## 关联 Issue

Closes #127

## 自查清单

- [x] 本地 `wails dev` 跑通并自测过改动
- [x] Go 代码已 `gofmt -w` 格式化，`go vet ./...`、`go test ./backend/...` 通过
- [x] 前端 `npm run lint` 无 error（无前端改动）
- [x] 新增/修改的 UI 文案已补全 12 个语言（无 UI 改动）
- [x] 未夹带与本 PR 无关的改动
