### PR TITLE
fix(docs): 更新 README 中 Star 增长图表为 star-history.dera.page

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -299,11 +299,11 @@ git checkout -b feature/your-feature
 
 ## Star History
 
-<a href="https://www.star-history.com/#Gridea-Pro/gridea-pro&Date">
+<a href="https://star-history.dera.page/#Gridea-Pro/gridea-pro&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Gridea-Pro/gridea-pro&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Gridea-Pro/gridea-pro&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -312,11 +312,11 @@ git checkout -b feature/your-feature
 
 ## Star 增长
 
-<a href="https://www.star-history.com/#Gridea-Pro/gridea-pro&Date">
+<a href="https://star-history.dera.page/#Gridea-Pro/gridea-pro&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Gridea-Pro/gridea-pro&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Gridea-Pro/gridea-pro&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Gridea-Pro/gridea-pro&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
### 问题描述

README 中的 Star 增长图表目前无法正常显示，原因在于 GitHub stargazer API 的限制导致图表请求失效。

### 解决方案

将图表切换至无 API Token 需求、同一域名同时处理 API 与前端请求的替代服务（star-history.dera.page）：

1. **替换域名** - 将 README.md 与 README-en.md 中的 `star-history.com` / `api.star-history.com` 统一替换为 `star-history.dera.page`
2. **保持图表接口** - `/svg` 图表接口保持不变，仅更新域名

### 改动范围

- `README.md` - 更新 Star 增长图表的链接与域名
- `README-en.md` - 更新 Star History 图表的链接与域名

### 测试

已在本地验证替换后的链接格式正确。